### PR TITLE
[fix] `clang-format` version mismatch

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install clang-format
-        run: sudo apt-get update && sudo apt-get install -y clang-format-17
+        run: pip install clang-format
 
       - name: Format
         run: |


### PR DESCRIPTION
`clang-format` is not tied to C++ version we're compiling against. We *should* be using the latest clang-format binary (even though we aren't necessarily using the latest c++ specification) for performance improvements, bug fixes, etc.

All the strife we've been having with `clang-format` comes from version mismatches between `clang-format` used locally (through vscode or the `clang-format` command) and the version used for CI.

Using clang-format v21 (matching the major version we use) fixes the inconsistencies between the two environments. Unfortunately, the ubuntu LTS version github actions uses locks the respositories apt-get is able to use to install clang-format to only v19. We can use pip to get the latest clang-format though, which is what this pull request updates the CI to do.