### PR TITLE
[feat] Kebab Files

### DIFF
--- a/src/film/image_buffer.cc
+++ b/src/film/image_buffer.cc
@@ -69,6 +69,13 @@ void ImageBuffer::WritePPM(const std::string& filename) const {
  * ======================================================================================
  */
 
+DeepImageBuffer::DeepImageBuffer(int width, int height, size_t totalSamples)
+    : width_(width), height_(height) {
+
+    pixelOffsets_.resize(width * height + 1);
+    allSamples_.resize(totalSamples);
+}
+
 DeepImageBuffer::DeepImageBuffer(int width, int height, size_t totalSamples,
                                  const Imf::Array2D<unsigned int>& sampleCounts)
     : width_(width), height_(height) {

--- a/src/film/image_buffer.cc
+++ b/src/film/image_buffer.cc
@@ -71,7 +71,6 @@ void ImageBuffer::WritePPM(const std::string& filename) const {
 
 DeepImageBuffer::DeepImageBuffer(int width, int height, size_t totalSamples)
     : width_(width), height_(height) {
-
     pixelOffsets_.resize(width * height + 1);
     allSamples_.resize(totalSamples);
 }

--- a/src/film/image_buffer.h
+++ b/src/film/image_buffer.h
@@ -60,6 +60,7 @@ class DeepImageBuffer {
     friend class ImageIO;
 
  public:
+    DeepImageBuffer(int width, int height, size_t totalSamples);
     DeepImageBuffer(int width, int height, size_t totalSamples,
                     const Imf::Array2D<unsigned int>& sampleCounts);
 

--- a/src/film/image_buffer.h
+++ b/src/film/image_buffer.h
@@ -56,7 +56,7 @@ class DeepImageBuffer {
     // This gives ImageIO full access to private/protected members
     friend class ImageIO;
 
- public:
+  public:
     DeepImageBuffer(int width, int height, size_t totalSamples);
     DeepImageBuffer(int width, int height, size_t totalSamples,
                     const Imf::Array2D<unsigned int>& sampleCounts);

--- a/src/film/image_buffer.h
+++ b/src/film/image_buffer.h
@@ -10,9 +10,11 @@
 
 namespace skwr {
 
+// Tells compiler "ImageIO" exists
+class ImageIO;
+
 class ImageBuffer {
-  public:
-    ImageBuffer(int width, int height);
+  public:ImageBuffer(int width, int height);
 
     // Set a pixel's color (0,0 is top-left usually)
     void SetPixel(int x, int y, const Spectrum& s);
@@ -62,7 +64,10 @@ struct MutableDeepPixelView {
 };
 
 class DeepImageBuffer {
-  public:
+    // This gives ImageIO full access to private/protected members
+    friend class ImageIO;
+
+ public:
     DeepImageBuffer(int width, int height, size_t totalSamples,
                     const Imf::Array2D<unsigned int>& sampleCounts);
 

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -276,10 +276,12 @@ DeepImageBuffer ImageIO::LoadKebab(const std::string& filename) {
     DeepImageBuffer buf(header.width, header.height, header.totalSamples);
 
     // Read pixel offset data
-    in.read(reinterpret_cast<char*>(buf.pixelOffsets_.data()), buf.pixelOffsets_.size() * sizeof(size_t));
+    in.read(reinterpret_cast<char*>(buf.pixelOffsets_.data()),
+            buf.pixelOffsets_.size() * sizeof(size_t));
 
     // Read sample data
-    in.read(reinterpret_cast<char*>(buf.allSamples_.data()), buf.allSamples_.size() * sizeof(DeepSample));
+    in.read(reinterpret_cast<char*>(buf.allSamples_.data()),
+            buf.allSamples_.size() * sizeof(DeepSample));
 
     in.close();
 

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -312,7 +312,6 @@ void ImageIO::SaveKebab(const DeepImageBuffer& buf, const std::string& filename)
         .width = static_cast<uint32_t>(buf.width_),
         .height = static_cast<uint32_t>(buf.height_),
         .totalSamples = static_cast<uint64_t>(buf.allSamples_.size()),
-        .totalPixels = static_cast<uint32_t>(buf.pixelOffsets_.size())
     };
     out.write(reinterpret_cast<const char*>(&header), sizeof(header));
 

--- a/src/io/image_io.h
+++ b/src/io/image_io.h
@@ -1,6 +1,7 @@
 #ifndef IMAGE_IO_H
 #define IMAGE_IO_H
 
+#include <cstdint>
 #include <string>
 
 #include "film/image_buffer.h"
@@ -13,9 +14,21 @@ class ImageIO {
 
     static void SaveEXR(const DeepImageBuffer& buf, const std::string filename);
 
+    static void SaveKebab(const DeepImageBuffer& buf, const std::string& filename);
+
     static FlatImageBuffer LoadPPM(const std::string filename);
 
     static DeepImageBuffer LoadEXR(const std::string filename);
+
+    static DeepImageBuffer LoadKebab(const std::string& filename);
+};
+
+struct KebabHeader {
+    char magic[4] = {'K', 'E', 'B', 'B'}; // New Magic: KEBB
+    uint32_t width;
+    uint32_t height;
+    uint64_t totalSamples;
+    uint32_t totalPixels;
 };
 
 }  // namespace skwr

--- a/src/io/image_io.h
+++ b/src/io/image_io.h
@@ -24,7 +24,7 @@ class ImageIO {
 };
 
 struct KebabHeader {
-    char magic[4] = {'K', 'E', 'B', 'B'}; // Unique Magic: KEBB
+    char magic[4] = {'K', 'E', 'B', 'B'};  // Unique Magic: KEBB
     uint32_t width;
     uint32_t height;
     uint64_t totalSamples;

--- a/src/io/image_io.h
+++ b/src/io/image_io.h
@@ -24,11 +24,10 @@ class ImageIO {
 };
 
 struct KebabHeader {
-    char magic[4] = {'K', 'E', 'B', 'B'}; // New Magic: KEBB
+    char magic[4] = {'K', 'E', 'B', 'B'}; // Unique Magic: KEBB
     uint32_t width;
     uint32_t height;
     uint64_t totalSamples;
-    uint32_t totalPixels;
 };
 
 }  // namespace skwr


### PR DESCRIPTION
This PR should investigate the use of our custom `.kebab` file format for disk file storage between the renderer and compositor. With proper compression and smart design, this object dump may be more efficient than openexr for our purposes. It is an attempt to trim the fat around loading/saving EXR images using their complex library.

Kind of a low priority thing that we can look at later. Closes #48.