### PR TITLE
[bugfix] Map Textures Correctly

### DIFF
--- a/skewer/src/materials/texture.cc
+++ b/skewer/src/materials/texture.cc
@@ -14,6 +14,7 @@ namespace skwr {
 
 bool ImageTexture::Load(const std::string& filepath) {
     int n;
+    stbi_set_flip_vertically_on_load(true);
     float* raw = stbi_loadf(filepath.c_str(), &width, &height, &n, 3);
     if (!raw) {
         std::cerr << "[Texture] Failed to load: " << filepath << " (" << stbi_failure_reason()


### PR DESCRIPTION
Added `stbi_set_flip_vertically_on_load(true);` to your `ImageTexture::Load` function in `skewer/src/materials/texture.cc`. This tells the image loader to flip the image vertically so the pixels align with the OBJ's UV map. 

Wavefront OBJ files map their UV coordinates starting with V=0 at the bottom-left.