### PR TITLE
[feat] Composite Job

### DIFF
--- a/LOCAL_DEPLOYMENT.md
+++ b/LOCAL_DEPLOYMENT.md
@@ -56,23 +56,25 @@ go run apps/cli/main.go help
 
 ### Common CLI Commands
 
-#### 1. Submitting a Job (`submit`)
+#### 1. Rendering a Scene (`render`)
 
-The `submit` command packages your rendering parameters and sends them to the Coordinator. The coordinator will break the job down into atomic tasks and distribute them to the workers.
+The `render` command packages your rendering parameters and sends them to the Coordinator. The coordinator will break the job down into atomic tasks and distribute them to the compute workers.
 
-**Basic Submission (Using Scene Defaults):**
+**Basic Rendering (Using Scene Defaults):**
 ```bash
-./apps/cli/skewer-cli submit \
+./skewer-cli render \
+  --name my_panda_render \
   --scene data/scenes/panda-####.json \
   --frames 4 \
   --output data/renders/test_panda/
 ```
 *Note: Using `####` in the filename tells the coordinator to render a sequence of frames (e.g., `panda-0001.json`, `panda-0002.json`).*
 
-**Advanced Submission (Overriding Quality Settings):**
+**Advanced Rendering (Overriding Quality Settings):**
 You can override the JSON scene file's defaults using CLI flags:
 ```bash
-./apps/cli/skewer-cli submit \
+./skewer-cli render \
+  --name high_res_panda \
   --scene data/scenes/panda-####.json \
   --frames 4 \
   --samples 256 \
@@ -91,12 +93,37 @@ You can override the JSON scene file's defaults using CLI flags:
 
 *When successful, the CLI will output your newly generated `Job ID`.*
 
-#### 2. Checking Job Status (`status`)
+#### 2. Deep Compositing (`composite`)
+
+The `composite` command tells the Loom workers to physically merge multiple Deep EXR layers (e.g. merging a dynamic character's frames with a static background). The resulting output is a standard **Flat EXR** 2D image, which can be viewed natively in macOS Preview or using professional tools like [DJV Imaging](https://darbyjohnston.github.io/DJV/).
+
+**Method A: Using Job Dependencies**
+If you just rendered two scenes via Skewer, you can automatically composite them by linking their Job IDs. The Coordinator will automatically evaluate where they saved their files:
+```bash
+./skewer-cli composite \
+  --name auto_composite \
+  --depends-on <JOB_ID_1>,<JOB_ID_2> \
+  --output data/renders/final_image/
+```
+
+**Method B: Using Existing Disk Files (`--layers`)**
+If you have existing EXRs, provide a comma-separated list of folder prefixes. 
+Use the pipe `|` to specify the extension and frame count limit `path/prefix|.ext|frames`:
+```bash
+./skewer-cli composite \
+  --name explicit_composite \
+  --layers "data/renders/pandas|.exr|10,data/renders/cloud|.exr|1" \
+  --frames 10 \
+  --output data/renders/custom_final/
+```
+*In the example above, the compositor processes 10 consecutive frames from `pandas`, continually merging them over the exact same single `frame-0001` from the `cloud` background.*
+
+#### 3. Checking Job Status (`status`)
 
 To monitor the progress of a submitted job, use the `status` command and pass the `Job ID`:
 
 ```bash
-./apps/cli/skewer-cli status --job <YOUR_JOB_ID>
+./skewer-cli status --job <YOUR_JOB_ID>
 ```
 
 **Example Output:**
@@ -107,12 +134,12 @@ Job Status: JOB_STATUS_RUNNING
 Progress: 25.0%
 ```
 
-#### 3. Canceling a Job (`cancel`)
+#### 4. Canceling a Job (`cancel`)
 
 If you need to stop a long-running render, you can kill it in the Coordinator:
 
 ```bash
-./apps/cli/skewer-cli cancel --job <YOUR_JOB_ID>
+./skewer-cli cancel --job <YOUR_JOB_ID>
 ```
 This drops all pending tasks for the job and prevents further processing.
 

--- a/README.md
+++ b/README.md
@@ -50,4 +50,8 @@ ctest --preset ci
 
 ## Deployment & CLI
 
-For instructions on deploying the cluster locally (using OrbStack/Minikube) and using the `skewer-cli` to submit and manage rendering jobs, please refer to the [Local Deployment & CLI Guide](LOCAL_DEPLOYMENT.md).
+The distributed worker cluster manages rendering and compositing workloads. Control the cluster via the `skewer-cli` interface:
+- **`render`**: Submit standard `.json` scenes to the compute cluster.
+- **`composite`**: Deep merge layered EXRs using the Loom pipeline.
+
+For automated local deployment scripts (OrbStack/Minikube) and the exhaustive CLI manual, please refer directly to the [Local Deployment & CLI Guide](LOCAL_DEPLOYMENT.md).

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -36,3 +36,6 @@ add_custom_command(
 add_library(coordinator_proto STATIC "${PROTO_SRC}" "${GRPC_SRC}")
 target_include_directories(coordinator_proto PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(coordinator_proto PUBLIC gRPC::grpc++ protobuf::libprotobuf)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(coordinator_proto PRIVATE -Wno-nullability-extension -Wno-error=nullability-extension)
+endif()

--- a/api/proto/coordinator/v1/coordinator.pb.go
+++ b/api/proto/coordinator/v1/coordinator.pb.go
@@ -759,7 +759,8 @@ type WorkPackage_RenderTask struct {
 }
 
 type WorkPackage_CompositeTask struct {
-	// Run by Loom: Ingests final Deep EXRs from entirely different Jobs (e.g. Smoke + Person) and deep-merges them
+	// Run by Loom: Ingests final Deep EXRs from entirely different Jobs (e.g. Smoke + Person)
+	// and deep-merges them
 	CompositeTask *CompositeTask `protobuf:"bytes,5,opt,name=composite_task,json=compositeTask,proto3,oneof"`
 }
 
@@ -887,7 +888,8 @@ func (x *RenderTask) GetMaxSamples() int32 {
 
 type CompositeTask struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The merged, FINAL Deep EXR frames from different Render Jobs to holdout/blend (after they've been "merged" from sample splitting)
+	// The merged, FINAL Deep EXR frames from different Render Jobs to holdout/blend (after they've
+	// been "merged" from sample splitting)
 	LayerUris     []string `protobuf:"bytes,1,rep,name=layer_uris,json=layerUris,proto3" json:"layer_uris,omitempty"`
 	Width         int32    `protobuf:"varint,2,opt,name=width,proto3" json:"width,omitempty"`
 	Height        int32    `protobuf:"varint,3,opt,name=height,proto3" json:"height,omitempty"`
@@ -1093,6 +1095,110 @@ func (x *ReportTaskResultResponse) GetAcknowledged() bool {
 	return false
 }
 
+type ReportTaskProgressRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	TaskId          string                 `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	WorkerId        string                 `protobuf:"bytes,2,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty"`
+	ProgressPercent float32                `protobuf:"fixed32,3,opt,name=progress_percent,json=progressPercent,proto3" json:"progress_percent,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ReportTaskProgressRequest) Reset() {
+	*x = ReportTaskProgressRequest{}
+	mi := &file_api_proto_coordinator_v1_coordinator_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportTaskProgressRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportTaskProgressRequest) ProtoMessage() {}
+
+func (x *ReportTaskProgressRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_coordinator_v1_coordinator_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportTaskProgressRequest.ProtoReflect.Descriptor instead.
+func (*ReportTaskProgressRequest) Descriptor() ([]byte, []int) {
+	return file_api_proto_coordinator_v1_coordinator_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ReportTaskProgressRequest) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+func (x *ReportTaskProgressRequest) GetWorkerId() string {
+	if x != nil {
+		return x.WorkerId
+	}
+	return ""
+}
+
+func (x *ReportTaskProgressRequest) GetProgressPercent() float32 {
+	if x != nil {
+		return x.ProgressPercent
+	}
+	return 0
+}
+
+type ReportTaskProgressResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Acknowledged  bool                   `protobuf:"varint,1,opt,name=acknowledged,proto3" json:"acknowledged,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportTaskProgressResponse) Reset() {
+	*x = ReportTaskProgressResponse{}
+	mi := &file_api_proto_coordinator_v1_coordinator_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportTaskProgressResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportTaskProgressResponse) ProtoMessage() {}
+
+func (x *ReportTaskProgressResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_coordinator_v1_coordinator_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportTaskProgressResponse.ProtoReflect.Descriptor instead.
+func (*ReportTaskProgressResponse) Descriptor() ([]byte, []int) {
+	return file_api_proto_coordinator_v1_coordinator_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ReportTaskProgressResponse) GetAcknowledged() bool {
+	if x != nil {
+		return x.Acknowledged
+	}
+	return false
+}
+
 var File_api_proto_coordinator_v1_coordinator_proto protoreflect.FileDescriptor
 
 const file_api_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
@@ -1192,13 +1298,20 @@ const file_api_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"output_uri\x18\x06 \x01(\tR\toutputUri\x12*\n" +
 	"\x11execution_time_ms\x18\a \x01(\x03R\x0fexecutionTimeMs\">\n" +
 	"\x18ReportTaskResultResponse\x12\"\n" +
-	"\facknowledged\x18\x01 \x01(\bR\facknowledged2\xb4\x04\n" +
+	"\facknowledged\x18\x01 \x01(\bR\facknowledged\"|\n" +
+	"\x19ReportTaskProgressRequest\x12\x17\n" +
+	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x1b\n" +
+	"\tworker_id\x18\x02 \x01(\tR\bworkerId\x12)\n" +
+	"\x10progress_percent\x18\x03 \x01(\x02R\x0fprogressPercent\"@\n" +
+	"\x1aReportTaskProgressResponse\x12\"\n" +
+	"\facknowledged\x18\x01 \x01(\bR\facknowledged2\xb5\x05\n" +
 	"\x12CoordinatorService\x12d\n" +
 	"\tSubmitJob\x12*.api.proto.coordinator.v1.SubmitJobRequest\x1a+.api.proto.coordinator.v1.SubmitJobResponse\x12m\n" +
 	"\fGetJobStatus\x12-.api.proto.coordinator.v1.GetJobStatusRequest\x1a..api.proto.coordinator.v1.GetJobStatusResponse\x12d\n" +
 	"\tCancelJob\x12*.api.proto.coordinator.v1.CancelJobRequest\x1a+.api.proto.coordinator.v1.CancelJobResponse\x12h\n" +
 	"\rGetWorkStream\x12..api.proto.coordinator.v1.GetWorkStreamRequest\x1a%.api.proto.coordinator.v1.WorkPackage0\x01\x12y\n" +
-	"\x10ReportTaskResult\x121.api.proto.coordinator.v1.ReportTaskResultRequest\x1a2.api.proto.coordinator.v1.ReportTaskResultResponseBIZGgithub.com/skewer-project/skewer/api/proto/coordinator/v1;coordinatorv1b\x06proto3"
+	"\x10ReportTaskResult\x121.api.proto.coordinator.v1.ReportTaskResultRequest\x1a2.api.proto.coordinator.v1.ReportTaskResultResponse\x12\x7f\n" +
+	"\x12ReportTaskProgress\x123.api.proto.coordinator.v1.ReportTaskProgressRequest\x1a4.api.proto.coordinator.v1.ReportTaskProgressResponseBIZGgithub.com/skewer-project/skewer/api/proto/coordinator/v1;coordinatorv1b\x06proto3"
 
 var (
 	file_api_proto_coordinator_v1_coordinator_proto_rawDescOnce sync.Once
@@ -1213,7 +1326,7 @@ func file_api_proto_coordinator_v1_coordinator_proto_rawDescGZIP() []byte {
 }
 
 var file_api_proto_coordinator_v1_coordinator_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_proto_coordinator_v1_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_api_proto_coordinator_v1_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_api_proto_coordinator_v1_coordinator_proto_goTypes = []any{
 	(GetJobStatusResponse_JobStatus)(0), // 0: api.proto.coordinator.v1.GetJobStatusResponse.JobStatus
 	(*SubmitJobRequest)(nil),            // 1: api.proto.coordinator.v1.SubmitJobRequest
@@ -1230,6 +1343,8 @@ var file_api_proto_coordinator_v1_coordinator_proto_goTypes = []any{
 	(*CompositeTask)(nil),               // 12: api.proto.coordinator.v1.CompositeTask
 	(*ReportTaskResultRequest)(nil),     // 13: api.proto.coordinator.v1.ReportTaskResultRequest
 	(*ReportTaskResultResponse)(nil),    // 14: api.proto.coordinator.v1.ReportTaskResultResponse
+	(*ReportTaskProgressRequest)(nil),   // 15: api.proto.coordinator.v1.ReportTaskProgressRequest
+	(*ReportTaskProgressResponse)(nil),  // 16: api.proto.coordinator.v1.ReportTaskProgressResponse
 }
 var file_api_proto_coordinator_v1_coordinator_proto_depIdxs = []int32{
 	2,  // 0: api.proto.coordinator.v1.SubmitJobRequest.render_job:type_name -> api.proto.coordinator.v1.RenderJob
@@ -1242,13 +1357,15 @@ var file_api_proto_coordinator_v1_coordinator_proto_depIdxs = []int32{
 	7,  // 7: api.proto.coordinator.v1.CoordinatorService.CancelJob:input_type -> api.proto.coordinator.v1.CancelJobRequest
 	9,  // 8: api.proto.coordinator.v1.CoordinatorService.GetWorkStream:input_type -> api.proto.coordinator.v1.GetWorkStreamRequest
 	13, // 9: api.proto.coordinator.v1.CoordinatorService.ReportTaskResult:input_type -> api.proto.coordinator.v1.ReportTaskResultRequest
-	4,  // 10: api.proto.coordinator.v1.CoordinatorService.SubmitJob:output_type -> api.proto.coordinator.v1.SubmitJobResponse
-	6,  // 11: api.proto.coordinator.v1.CoordinatorService.GetJobStatus:output_type -> api.proto.coordinator.v1.GetJobStatusResponse
-	8,  // 12: api.proto.coordinator.v1.CoordinatorService.CancelJob:output_type -> api.proto.coordinator.v1.CancelJobResponse
-	10, // 13: api.proto.coordinator.v1.CoordinatorService.GetWorkStream:output_type -> api.proto.coordinator.v1.WorkPackage
-	14, // 14: api.proto.coordinator.v1.CoordinatorService.ReportTaskResult:output_type -> api.proto.coordinator.v1.ReportTaskResultResponse
-	10, // [10:15] is the sub-list for method output_type
-	5,  // [5:10] is the sub-list for method input_type
+	15, // 10: api.proto.coordinator.v1.CoordinatorService.ReportTaskProgress:input_type -> api.proto.coordinator.v1.ReportTaskProgressRequest
+	4,  // 11: api.proto.coordinator.v1.CoordinatorService.SubmitJob:output_type -> api.proto.coordinator.v1.SubmitJobResponse
+	6,  // 12: api.proto.coordinator.v1.CoordinatorService.GetJobStatus:output_type -> api.proto.coordinator.v1.GetJobStatusResponse
+	8,  // 13: api.proto.coordinator.v1.CoordinatorService.CancelJob:output_type -> api.proto.coordinator.v1.CancelJobResponse
+	10, // 14: api.proto.coordinator.v1.CoordinatorService.GetWorkStream:output_type -> api.proto.coordinator.v1.WorkPackage
+	14, // 15: api.proto.coordinator.v1.CoordinatorService.ReportTaskResult:output_type -> api.proto.coordinator.v1.ReportTaskResultResponse
+	16, // 16: api.proto.coordinator.v1.CoordinatorService.ReportTaskProgress:output_type -> api.proto.coordinator.v1.ReportTaskProgressResponse
+	11, // [11:17] is the sub-list for method output_type
+	5,  // [5:11] is the sub-list for method input_type
 	5,  // [5:5] is the sub-list for extension type_name
 	5,  // [5:5] is the sub-list for extension extendee
 	0,  // [0:5] is the sub-list for field type_name
@@ -1273,7 +1390,7 @@ func file_api_proto_coordinator_v1_coordinator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_proto_coordinator_v1_coordinator_proto_rawDesc), len(file_api_proto_coordinator_v1_coordinator_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   14,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/coordinator/v1/coordinator.proto
+++ b/api/proto/coordinator/v1/coordinator.proto
@@ -16,151 +16,164 @@ option go_package = "github.com/skewer-project/skewer/api/proto/coordinator/v1;c
 */
 
 service CoordinatorService {
-  // External API for CLI
-  rpc SubmitJob(SubmitJobRequest) returns (SubmitJobResponse);
-  rpc GetJobStatus(GetJobStatusRequest) returns (GetJobStatusResponse);
-  rpc CancelJob(CancelJobRequest) returns (CancelJobResponse);
+    // External API for CLI
+    rpc SubmitJob(SubmitJobRequest) returns (SubmitJobResponse);
+    rpc GetJobStatus(GetJobStatusRequest) returns (GetJobStatusResponse);
+    rpc CancelJob(CancelJobRequest) returns (CancelJobResponse);
 
-  // Internal API for Skewer and Loom GKE Workers
-  rpc GetWorkStream(GetWorkStreamRequest) returns (stream WorkPackage);
-  rpc ReportTaskResult(ReportTaskResultRequest) returns (ReportTaskResultResponse);
+    // Internal API for Skewer and Loom GKE Workers
+    rpc GetWorkStream(GetWorkStreamRequest) returns (stream WorkPackage);
+    rpc ReportTaskResult(ReportTaskResultRequest) returns (ReportTaskResultResponse);
+    rpc ReportTaskProgress(ReportTaskProgressRequest) returns (ReportTaskProgressResponse);
 }
 
 ///* "Job" Submission Level *///
 message SubmitJobRequest {
-  string job_id = 1; // UUID of job for tracking
-  string job_name = 2; // eg. "smoke_layer", "ball_layer", "final_composite"
+    string job_id = 1;    // UUID of job for tracking
+    string job_name = 2;  // eg. "smoke_layer", "ball_layer", "final_composite"
 
-  repeated string depends_on = 3;
+    repeated string depends_on = 3;
 
-  // General job information
-  int32 num_frames = 4;
-  int32 width = 5;
-  int32 height = 6;
+    // General job information
+    int32 num_frames = 4;
+    int32 width = 5;
+    int32 height = 6;
 
-  oneof job_type {
-    RenderJob render_job = 7;
-    CompositeJob composite_job = 8;
-  }
+    oneof job_type {
+        RenderJob render_job = 7;
+        CompositeJob composite_job = 8;
+    }
 }
 
 message RenderJob {
-  string scene_uri = 1;
-  int32 max_samples = 2; // max number of rays shot per pixel e.g., 1024
-  string output_uri_prefix = 3; // gs://bucket/renders/smoke/
-  bool enable_deep = 4;
-  int32 threads = 5;
+    string scene_uri = 1;
+    int32 max_samples = 2;         // max number of rays shot per pixel e.g., 1024
+    string output_uri_prefix = 3;  // gs://bucket/renders/smoke/
+    bool enable_deep = 4;
+    int32 threads = 5;
 
-  // Adaptive sampling. When noise_threshold > 0, pixels that converge below
-  // the threshold stop sampling early. 0 disables adaptive sampling.
-  float noise_threshold = 6;
-  int32 min_samples = 7; // Minimum samples before convergence check (default 0 = use scene JSON)
-  int32 adaptive_step = 8; // Samples between convergence checks (default 0 = use scene JSON)
+    // Adaptive sampling. When noise_threshold > 0, pixels that converge below
+    // the threshold stop sampling early. 0 disables adaptive sampling.
+    float noise_threshold = 6;
+    int32 min_samples = 7;  // Minimum samples before convergence check (default 0 = use scene JSON)
+    int32 adaptive_step = 8;  // Samples between convergence checks (default 0 = use scene JSON)
 }
 
 message CompositeJob {
-  // The layers to combine. For frame x, Loom will look for:
-  // gs://bucket/renders/smoke/frame-0005.exr and gs://bucket/renders/person/frame-0005.exr
-  repeated string layer_uri_prefixes = 1;
-  string output_uri_prefix = 2;
+    // The layers to combine. For frame x, Loom will look for:
+    // gs://bucket/renders/smoke/frame-0005.exr and gs://bucket/renders/person/frame-0005.exr
+    repeated string layer_uri_prefixes = 1;
+    string output_uri_prefix = 2;
 }
 
 message SubmitJobResponse {
-  string job_id = 1;
+    string job_id = 1;
 }
 
 ///* Job Tracking API for User *///
 message GetJobStatusRequest {
-  string job_id = 1;
+    string job_id = 1;
 }
 
 message GetJobStatusResponse {
-  enum JobStatus {
-    JOB_STATUS_UNSPECIFIED = 0;
-    JOB_STATUS_PENDING_DEPENDENCIES = 1; // waiting for dependency jobs
-    JOB_STATUS_QUEUED = 2;
-    JOB_STATUS_RUNNING = 3;
-    JOB_STATUS_COMPLETED = 4;
-    JOB_STATUS_FAILED = 5;
-  }
-  JobStatus job_status = 1;
-  float progress_percent = 2;
-  string error_message = 3;
+    enum JobStatus {
+        JOB_STATUS_UNSPECIFIED = 0;
+        JOB_STATUS_PENDING_DEPENDENCIES = 1;  // waiting for dependency jobs
+        JOB_STATUS_QUEUED = 2;
+        JOB_STATUS_RUNNING = 3;
+        JOB_STATUS_COMPLETED = 4;
+        JOB_STATUS_FAILED = 5;
+    }
+    JobStatus job_status = 1;
+    float progress_percent = 2;
+    string error_message = 3;
 }
 
 message CancelJobRequest {
-  string job_id = 1;
+    string job_id = 1;
 }
 
 message CancelJobResponse {
-  bool success = 1;
+    bool success = 1;
 }
 
 ///* Worker Execution *///
 message GetWorkStreamRequest {
-  string worker_id = 1; // UUID of skewer/loom pod
+    string worker_id = 1;  // UUID of skewer/loom pod
 
-  // Any tags to ensure workers only get tasks they can handle
-  // e.g., ["gpu", "skewer"] or ["high-mem", "loom"]
-  repeated string capabilities = 2;
+    // Any tags to ensure workers only get tasks they can handle
+    // e.g., ["gpu", "skewer"] or ["high-mem", "loom"]
+    repeated string capabilities = 2;
 }
 
 message WorkPackage {
-  string job_id = 1;
-  string task_id = 2;
-  string frame_id = 3;
+    string job_id = 1;
+    string task_id = 2;
+    string frame_id = 3;
 
-  oneof payload {
-    // Run by Skewer: Render a sample chunk
-    RenderTask render_task = 4;
+    oneof payload {
+        // Run by Skewer: Render a sample chunk
+        RenderTask render_task = 4;
 
-    // Run by Loom: Ingests final Deep EXRs from entirely different Jobs (e.g. Smoke + Person) and deep-merges them
-    CompositeTask composite_task = 5;
-  }
+        // Run by Loom: Ingests final Deep EXRs from entirely different Jobs (e.g. Smoke + Person)
+        // and deep-merges them
+        CompositeTask composite_task = 5;
+    }
 }
 
 message RenderTask {
-  // Scene information
-  string scene_uri = 1;
-  int32 width = 2;
-  int32 height = 3;
+    // Scene information
+    string scene_uri = 1;
+    int32 width = 2;
+    int32 height = 3;
 
-  string output_uri = 4; // gs://bucket/renders/smoke/frame-0005-chunk-0.exr
-  bool enable_deep = 5;
-  int32 threads = 6;
+    string output_uri = 4;  // gs://bucket/renders/smoke/frame-0005-chunk-0.exr
+    bool enable_deep = 5;
+    int32 threads = 6;
 
-  // Adaptive sampling (forwarded from RenderJob)
-  float noise_threshold = 7;
-  int32 min_samples = 8;
-  int32 adaptive_step = 9;
-  int32 max_samples = 10;
+    // Adaptive sampling (forwarded from RenderJob)
+    float noise_threshold = 7;
+    int32 min_samples = 8;
+    int32 adaptive_step = 9;
+    int32 max_samples = 10;
 }
 
 message CompositeTask {
-  // The merged, FINAL Deep EXR frames from different Render Jobs to holdout/blend (after they've been "merged" from sample splitting)
-  repeated string layer_uris = 1;
+    // The merged, FINAL Deep EXR frames from different Render Jobs to holdout/blend (after they've
+    // been "merged" from sample splitting)
+    repeated string layer_uris = 1;
 
-  int32 width = 2;
-  int32 height = 3;
+    int32 width = 2;
+    int32 height = 3;
 
-  string output_uri = 4; // flattened 2D image
+    string output_uri = 4;  // flattened 2D image
 }
 
 ///* Worker Reporting *///
 message ReportTaskResultRequest {
-  // Identification of the job task and worker (may need to add frame number)
-  string task_id = 1;
-  string job_id = 2;
-  string worker_id = 3;
+    // Identification of the job task and worker (may need to add frame number)
+    string task_id = 1;
+    string job_id = 2;
+    string worker_id = 3;
 
-  // Generic response information
-  bool success = 4;
-  string error_message = 5;
-  string output_uri = 6;
+    // Generic response information
+    bool success = 4;
+    string error_message = 5;
+    string output_uri = 6;
 
-  int64 execution_time_ms = 7; // for metrics
+    int64 execution_time_ms = 7;  // for metrics
 }
 
 message ReportTaskResultResponse {
-  bool acknowledged = 1;
+    bool acknowledged = 1;
+}
+
+message ReportTaskProgressRequest {
+    string task_id = 1;
+    string worker_id = 2;
+    float progress_percent = 3;
+}
+
+message ReportTaskProgressResponse {
+    bool acknowledged = 1;
 }

--- a/api/proto/coordinator/v1/coordinator_grpc.pb.go
+++ b/api/proto/coordinator/v1/coordinator_grpc.pb.go
@@ -19,11 +19,12 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	CoordinatorService_SubmitJob_FullMethodName        = "/api.proto.coordinator.v1.CoordinatorService/SubmitJob"
-	CoordinatorService_GetJobStatus_FullMethodName     = "/api.proto.coordinator.v1.CoordinatorService/GetJobStatus"
-	CoordinatorService_CancelJob_FullMethodName        = "/api.proto.coordinator.v1.CoordinatorService/CancelJob"
-	CoordinatorService_GetWorkStream_FullMethodName    = "/api.proto.coordinator.v1.CoordinatorService/GetWorkStream"
-	CoordinatorService_ReportTaskResult_FullMethodName = "/api.proto.coordinator.v1.CoordinatorService/ReportTaskResult"
+	CoordinatorService_SubmitJob_FullMethodName          = "/api.proto.coordinator.v1.CoordinatorService/SubmitJob"
+	CoordinatorService_GetJobStatus_FullMethodName       = "/api.proto.coordinator.v1.CoordinatorService/GetJobStatus"
+	CoordinatorService_CancelJob_FullMethodName          = "/api.proto.coordinator.v1.CoordinatorService/CancelJob"
+	CoordinatorService_GetWorkStream_FullMethodName      = "/api.proto.coordinator.v1.CoordinatorService/GetWorkStream"
+	CoordinatorService_ReportTaskResult_FullMethodName   = "/api.proto.coordinator.v1.CoordinatorService/ReportTaskResult"
+	CoordinatorService_ReportTaskProgress_FullMethodName = "/api.proto.coordinator.v1.CoordinatorService/ReportTaskProgress"
 )
 
 // CoordinatorServiceClient is the client API for CoordinatorService service.
@@ -37,6 +38,7 @@ type CoordinatorServiceClient interface {
 	// Internal API for Skewer and Loom GKE Workers
 	GetWorkStream(ctx context.Context, in *GetWorkStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WorkPackage], error)
 	ReportTaskResult(ctx context.Context, in *ReportTaskResultRequest, opts ...grpc.CallOption) (*ReportTaskResultResponse, error)
+	ReportTaskProgress(ctx context.Context, in *ReportTaskProgressRequest, opts ...grpc.CallOption) (*ReportTaskProgressResponse, error)
 }
 
 type coordinatorServiceClient struct {
@@ -106,6 +108,16 @@ func (c *coordinatorServiceClient) ReportTaskResult(ctx context.Context, in *Rep
 	return out, nil
 }
 
+func (c *coordinatorServiceClient) ReportTaskProgress(ctx context.Context, in *ReportTaskProgressRequest, opts ...grpc.CallOption) (*ReportTaskProgressResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReportTaskProgressResponse)
+	err := c.cc.Invoke(ctx, CoordinatorService_ReportTaskProgress_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // CoordinatorServiceServer is the server API for CoordinatorService service.
 // All implementations must embed UnimplementedCoordinatorServiceServer
 // for forward compatibility.
@@ -117,6 +129,7 @@ type CoordinatorServiceServer interface {
 	// Internal API for Skewer and Loom GKE Workers
 	GetWorkStream(*GetWorkStreamRequest, grpc.ServerStreamingServer[WorkPackage]) error
 	ReportTaskResult(context.Context, *ReportTaskResultRequest) (*ReportTaskResultResponse, error)
+	ReportTaskProgress(context.Context, *ReportTaskProgressRequest) (*ReportTaskProgressResponse, error)
 	mustEmbedUnimplementedCoordinatorServiceServer()
 }
 
@@ -141,6 +154,9 @@ func (UnimplementedCoordinatorServiceServer) GetWorkStream(*GetWorkStreamRequest
 }
 func (UnimplementedCoordinatorServiceServer) ReportTaskResult(context.Context, *ReportTaskResultRequest) (*ReportTaskResultResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReportTaskResult not implemented")
+}
+func (UnimplementedCoordinatorServiceServer) ReportTaskProgress(context.Context, *ReportTaskProgressRequest) (*ReportTaskProgressResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ReportTaskProgress not implemented")
 }
 func (UnimplementedCoordinatorServiceServer) mustEmbedUnimplementedCoordinatorServiceServer() {}
 func (UnimplementedCoordinatorServiceServer) testEmbeddedByValue()                            {}
@@ -246,6 +262,24 @@ func _CoordinatorService_ReportTaskResult_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+func _CoordinatorService_ReportTaskProgress_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReportTaskProgressRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CoordinatorServiceServer).ReportTaskProgress(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CoordinatorService_ReportTaskProgress_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CoordinatorServiceServer).ReportTaskProgress(ctx, req.(*ReportTaskProgressRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // CoordinatorService_ServiceDesc is the grpc.ServiceDesc for CoordinatorService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -268,6 +302,10 @@ var CoordinatorService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ReportTaskResult",
 			Handler:    _CoordinatorService_ReportTaskResult_Handler,
+		},
+		{
+			MethodName: "ReportTaskProgress",
+			Handler:    _CoordinatorService_ReportTaskProgress_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/apps/cli/cmd/composite.go
+++ b/apps/cli/cmd/composite.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	coordinatorv1 "github.com/skewer-project/skewer/api/proto/coordinator/v1"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var (
+	compJobName   string
+	compOutputURI string
+	compNumFrames int32
+	compWidth     int32
+	compHeight    int32
+	compDependsOn []string
+	compLayers    []string
+)
+
+var compositeCmd = &cobra.Command{
+	Use:   "composite",
+	Short: "Submit a compositing job to the Skewer coordinator",
+	Long: `Submit a compositing job. If --layers is omitted, the coordinator will 
+automatically resolve input layers from the jobs listed in --depends-on.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Automate port-forwarding if needed
+		if err := ensureConnection(coordinatorAddr); err != nil {
+			log.Fatalf("Error establishing connection: %v", err)
+		}
+
+		conn, err := grpc.NewClient(coordinatorAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			log.Fatalf("Did not connect: %v", err)
+		}
+		defer conn.Close()
+		c := coordinatorv1.NewCoordinatorServiceClient(conn)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+
+		req := &coordinatorv1.SubmitJobRequest{
+			JobName:   compJobName,
+			NumFrames: compNumFrames,
+			Width:     compWidth,
+			Height:    compHeight,
+			DependsOn: compDependsOn,
+			JobType: &coordinatorv1.SubmitJobRequest_CompositeJob{
+				CompositeJob: &coordinatorv1.CompositeJob{
+					LayerUriPrefixes: compLayers,
+					OutputUriPrefix:  compOutputURI,
+				},
+			},
+		}
+
+		r, err := c.SubmitJob(ctx, req)
+		if err != nil {
+			log.Fatalf("Could not submit composite job: %v", err)
+		}
+		fmt.Printf("Composite job submitted successfully! Job ID: %s\n", r.GetJobId())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(compositeCmd)
+
+	compositeCmd.Flags().StringVarP(&compJobName, "name", "n", "skewer-composite", "Name of the job")
+	compositeCmd.Flags().StringVarP(&compOutputURI, "output", "o", "data/renders/", "Output URI prefix (can be local path or gs://)")
+	compositeCmd.Flags().Int32VarP(&compNumFrames, "frames", "f", 1, "Number of frames to composite")
+	compositeCmd.Flags().Int32VarP(&compWidth, "width", "W", 0, "Width of the output image (0 = use inputs)")
+	compositeCmd.Flags().Int32VarP(&compHeight, "height", "H", 0, "Height of the output image (0 = use inputs)")
+	compositeCmd.Flags().StringSliceVarP(&compDependsOn, "depends-on", "d", []string{}, "Comma-separated list of Job IDs this job depends on")
+	compositeCmd.Flags().StringSliceVarP(&compLayers, "layers", "l", []string{}, "Optional: Manual comma-separated list of layer URI prefixes")
+}

--- a/apps/cli/cmd/render.go
+++ b/apps/cli/cmd/render.go
@@ -27,10 +27,11 @@ var (
 	noiseThreshold float32
 	minSamples     int32
 	adaptiveStep   int32
+	dependsOn      []string
 )
 
-var submitCmd = &cobra.Command{
-	Use:   "submit",
+var renderCmd = &cobra.Command{
+	Use:   "render",
 	Short: "Submit a rendering job to the Skewer coordinator",
 	Run: func(cmd *cobra.Command, args []string) {
 		// Validation: Check if local scene files exist if '####' is present
@@ -67,6 +68,7 @@ var submitCmd = &cobra.Command{
 			NumFrames: numFrames,
 			Width:     width,
 			Height:    height,
+			DependsOn: dependsOn,
 			JobType: &coordinatorv1.SubmitJobRequest_RenderJob{
 				RenderJob: &coordinatorv1.RenderJob{
 					SceneUri:        sceneURI,
@@ -83,29 +85,30 @@ var submitCmd = &cobra.Command{
 
 		r, err := c.SubmitJob(ctx, req)
 		if err != nil {
-			log.Fatalf("Could not submit job: %v", err)
+			log.Fatalf("Could not submit renderjob: %v", err)
 		}
 		fmt.Printf("Job submitted successfully! Job ID: %s\n", r.GetJobId())
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(submitCmd)
+	rootCmd.AddCommand(renderCmd)
 
-	submitCmd.Flags().StringVarP(&sceneURI, "scene", "s", "", "URI of the scene file to render (can be local path or gs://)")
-	submitCmd.Flags().StringVarP(&jobName, "name", "n", "skewer-job", "Name of the job")
-	submitCmd.Flags().StringVarP(&outputURI, "output", "o", "data/renders/", "Output URI prefix (can be local path or gs://)")
-	submitCmd.Flags().Int32VarP(&numFrames, "frames", "f", 1, "Number of frames to render")
-	submitCmd.Flags().Int32VarP(&width, "width", "W", 0, "Width of the rendered image (0 = use scene JSON)")
-	submitCmd.Flags().Int32VarP(&height, "height", "H", 0, "Height of the rendered image (0 = use scene JSON)")
-	submitCmd.Flags().Int32VarP(&maxSamples, "samples", "S", 0, "Total samples per pixel (0 = use scene JSON)")
-	submitCmd.Flags().BoolVar(&enableDeep, "deep", false, "Enable deep output for the final image")
-	submitCmd.Flags().Int32VarP(&threads, "threads", "t", 0, "Number of threads per worker (0 = auto)")
-	submitCmd.Flags().Float32Var(&noiseThreshold, "noise-threshold", 0.0, "Adaptive sampling noise threshold (0 = use scene JSON setting)")
-	submitCmd.Flags().Int32Var(&minSamples, "min-samples", 0, "Minimum samples before adaptive convergence check (0 = use scene JSON setting)")
-	submitCmd.Flags().Int32Var(&adaptiveStep, "adaptive-step", 0, "Samples between adaptive convergence checks (0 = use scene JSON setting)")
+	renderCmd.Flags().StringVarP(&sceneURI, "scene", "s", "", "URI of the scene file to render (can be local path or gs://)")
+	renderCmd.Flags().StringVarP(&jobName, "name", "n", "skewer-job", "Name of the job")
+	renderCmd.Flags().StringVarP(&outputURI, "output", "o", "data/renders/", "Output URI prefix (can be local path or gs://)")
+	renderCmd.Flags().Int32VarP(&numFrames, "frames", "f", 1, "Number of frames to render")
+	renderCmd.Flags().Int32VarP(&width, "width", "W", 0, "Width of the rendered image (0 = use scene JSON)")
+	renderCmd.Flags().Int32VarP(&height, "height", "H", 0, "Height of the rendered image (0 = use scene JSON)")
+	renderCmd.Flags().Int32VarP(&maxSamples, "samples", "S", 0, "Total samples per pixel (0 = use scene JSON)")
+	renderCmd.Flags().BoolVar(&enableDeep, "deep", false, "Enable deep output for the final image")
+	renderCmd.Flags().Int32VarP(&threads, "threads", "t", 0, "Number of threads per worker (0 = auto)")
+	renderCmd.Flags().Float32Var(&noiseThreshold, "noise-threshold", 0.0, "Adaptive sampling noise threshold (0 = use scene JSON setting)")
+	renderCmd.Flags().Int32Var(&minSamples, "min-samples", 0, "Minimum samples before adaptive convergence check (0 = use scene JSON setting)")
+	renderCmd.Flags().Int32Var(&adaptiveStep, "adaptive-step", 0, "Samples between adaptive convergence checks (0 = use scene JSON setting)")
+	renderCmd.Flags().StringSliceVarP(&dependsOn, "depends-on", "d", []string{}, "Comma-separated list of Job IDs this job depends on")
 
-	if err := submitCmd.MarkFlagRequired("scene"); err != nil {
+	if err := renderCmd.MarkFlagRequired("scene"); err != nil {
 		log.Fatalf("Failed to mark 'scene' flag as required: %v", err)
 	}
 }

--- a/apps/cli/cmd/root.go
+++ b/apps/cli/cmd/root.go
@@ -26,7 +26,7 @@ func ensureConnection(addr string) error {
 		return nil
 	}
 
-	fmt.Println("[CLI] Coordinator not reachable. Attempting to port-forward...")
+	fmt.Println("[CLI]: Coordinator not reachable. Attempting to port-forward...")
 
 	// Extract the port from the address (e.g. "localhost:50051" -> "50051")
 	parts := strings.Split(addr, ":")

--- a/apps/coordinator/main.go
+++ b/apps/coordinator/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	ctx := context.Background()
 
-	go scheduler.StartSweeper(ctx, time.Hour, time.Minute)
+	go scheduler.StartSweeper(ctx, 2*time.Minute, 30*time.Second)
 
 	// Create Cloud Manager (passing an empty string for local testing if credentials aren't explicitly provided yet)
 	cloudManager, err := coordinator.NewK8sCloudManager(ctx, "")

--- a/deployments/k8s/coordinator.yaml
+++ b/deployments/k8s/coordinator.yaml
@@ -52,6 +52,13 @@ spec:
           ports:
             - containerPort: 50051
               name: grpc
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
           env:
             - name: LOCAL_STORAGE_BASE
               value: "/data"

--- a/deployments/k8s/loom-worker.yaml
+++ b/deployments/k8s/loom-worker.yaml
@@ -28,6 +28,8 @@ spec:
           env:
             - name: COORDINATOR_ADDR
               value: "skewer-coordinator.default.svc.cluster.local:50051"
+            - name: GRPC_DNS_RESOLVER
+              value: "native"
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/secrets/credentials.json"
           volumeMounts:
@@ -39,7 +41,7 @@ spec:
           resources:
             requests:
               cpu: "100m"
-              memory: "256Mi"
+              memory: "512Mi"
             limits:
               cpu: "2000m"
               memory: "4Gi"

--- a/deployments/k8s/skewer-worker.yaml
+++ b/deployments/k8s/skewer-worker.yaml
@@ -28,6 +28,8 @@ spec:
           env:
             - name: COORDINATOR_ADDR
               value: "skewer-coordinator.default.svc.cluster.local:50051"
+            - name: GRPC_DNS_RESOLVER
+              value: "native"
             - name: RENDER_THREADS
               value: "2"
             - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -41,7 +43,7 @@ spec:
           resources:
             requests:
               cpu: "100m"
-              memory: "256Mi"
+              memory: "512Mi"
             limits:
               cpu: "2000m"
               memory: "4Gi"

--- a/internal/coordinator/job.go
+++ b/internal/coordinator/job.go
@@ -11,7 +11,7 @@ import (
 // * Job Primitive * //
 // ================= //
 
-// Minimum for Job interface
+// Job interface
 type Job interface {
 	ID() string
 	GetDependencies() []string
@@ -19,6 +19,8 @@ type Job interface {
 	SetStatus(status pb.GetJobStatusResponse_JobStatus)
 	Progress() float32
 	GetOriginalReq() *pb.SubmitJobRequest
+	GetOutputPrefix() string
+	SetOutputPrefix(prefix string)
 }
 
 // The Render Job
@@ -57,6 +59,12 @@ func (rj *RenderJob) Progress() float32 {
 func (rj *RenderJob) GetOriginalReq() *pb.SubmitJobRequest {
 	return rj.OriginalReq
 }
+func (rj *RenderJob) GetOutputPrefix() string {
+	return rj.OriginalReq.GetRenderJob().GetOutputUriPrefix() // get protobuf field
+}
+func (rj *RenderJob) SetOutputPrefix(prefix string) {
+	rj.OriginalReq.GetRenderJob().OutputUriPrefix = prefix
+}
 
 // The Composite Job
 type CompositeJob struct {
@@ -93,6 +101,12 @@ func (cj *CompositeJob) Progress() float32 {
 }
 func (cj *CompositeJob) GetOriginalReq() *pb.SubmitJobRequest {
 	return cj.OriginalReq
+}
+func (cj *CompositeJob) GetOutputPrefix() string {
+	return cj.OriginalReq.GetCompositeJob().GetOutputUriPrefix() // get protobuf field
+}
+func (cj *CompositeJob) SetOutputPrefix(prefix string) {
+	cj.OriginalReq.GetCompositeJob().OutputUriPrefix = prefix
 }
 
 // ===================== //
@@ -139,15 +153,24 @@ func (jt *JobTracker) AddJob(job Job) error {
 			}
 		}
 
-		jt.activeJobs[job.ID()] = job // ALWAYS add it to active jobs!
+		jt.activeJobs[job.ID()] = job // ALWAYS add it to active jobs
+
+		// Calculate how many dependencies are actually pending
+		unmetDeps := 0
+		for _, depID := range jobDeps {
+			dep, exists := jt.activeJobs[depID]
+			if !exists || dep.GetStatus() != pb.GetJobStatusResponse_JOB_STATUS_COMPLETED {
+				unmetDeps++
+			}
+		}
 
 		// Add the job to the live tracker
-		if len(jobDeps) == 0 {
+		if unmetDeps == 0 {
 			job.SetStatus(pb.GetJobStatusResponse_JOB_STATUS_QUEUED)
 		} else {
 			job.SetStatus(pb.GetJobStatusResponse_JOB_STATUS_PENDING_DEPENDENCIES)
 		}
-		jt.pendingDeps[job.ID()] = len(jobDeps)
+		jt.pendingDeps[job.ID()] = unmetDeps
 
 		// Add the job and dependencies to the graph
 		jt.graph.AddNode(job)

--- a/internal/coordinator/scheduler.go
+++ b/internal/coordinator/scheduler.go
@@ -16,9 +16,10 @@ type Task struct {
 	FrameID string
 	Payload any // *pb.RenderTask or *pb.CompositeTask
 
-	CreatedAt time.Time
-	StartedAt time.Time // WHEN the worker pulled it
-	Retries   int32     // How many times it has been requeued
+	CreatedAt     time.Time
+	StartedAt     time.Time // WHEN the worker pulled it
+	LastHeartbeat time.Time // WHEN the worker last checked in
+	Retries       int32     // How many times it has been requeued
 }
 
 type Scheduler struct {
@@ -93,6 +94,7 @@ func (s *Scheduler) GetNextTask(ctx context.Context, capabilities []string) (*Ta
 
 				s.mu.Lock()
 				task.StartedAt = time.Now()
+				task.LastHeartbeat = time.Now()
 				s.activeTasks[task.ID] = task
 				s.mu.Unlock()
 
@@ -108,6 +110,7 @@ func (s *Scheduler) GetNextTask(ctx context.Context, capabilities []string) (*Ta
 
 				s.mu.Lock()
 				task.StartedAt = time.Now()
+				task.LastHeartbeat = time.Now()
 				s.activeTasks[task.ID] = task
 				s.mu.Unlock()
 
@@ -137,6 +140,16 @@ func (s *Scheduler) popActiveTask(taskID string) (*Task, bool) {
 		delete(s.activeTasks, taskID)
 	}
 	return task, exists
+}
+
+// Safely updates the heartbeat time
+func (s *Scheduler) UpdateHeartbeat(taskID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	task, exists := s.Task(taskID)
+	if exists {
+		task.LastHeartbeat = time.Now()
+	}
 }
 
 func (s *Scheduler) RequeueTask(taskID string) {
@@ -242,8 +255,8 @@ func (s *Scheduler) sweep(timeout time.Duration) {
 	// Lock just long enough to scan the map and remove the bad entries
 	s.mu.Lock()
 	for id, task := range s.activeTasks {
-		// TODO: Change StartedAt to LastHeartbeat if we implement
-		if now.Sub(task.StartedAt) > timeout {
+		// Use LastHeartbeat to determine if worker died (OOM)
+		if now.Sub(task.LastHeartbeat) > timeout {
 			deadTasks = append(deadTasks, task)
 			delete(s.activeTasks, id) // Remove it from active tracking
 		}
@@ -264,24 +277,23 @@ func (s *Scheduler) sweep(timeout time.Duration) {
 			continue
 		}
 
-		// Push it back to the queue
-		// Figure out which queue the dead task belongs to!
-		switch task.Payload.(type) {
+		// Push it back to the queue asynchronously to prevent locking the sweeper ticker
+		go func(t *Task) {
+			switch t.Payload.(type) {
+			case *pb.RenderTask:
+				s.skewerQueue <- t
+				fmt.Printf("[SCHEDULER] Worker timeout! Requeued Skewer task %s (Retry %d/3)\n", t.ID, t.Retries)
 
-		case *pb.RenderTask:
-			s.skewerQueue <- task
-			fmt.Printf("[SCHEDULER] Worker timeout! Requeued Skewer task %s (Retry %d/3)\n", task.ID, task.Retries)
-
-		case *pb.CompositeTask:
-			s.loomQueue <- task
-			fmt.Printf("[SCHEDULER] Worker timeout! Requeued Loom task %s (Retry %d/3)\n", task.ID, task.Retries)
-		}
+			case *pb.CompositeTask:
+				s.loomQueue <- t
+				fmt.Printf("[SCHEDULER] Worker timeout! Requeued Loom task %s (Retry %d/3)\n", t.ID, t.Retries)
+			}
+		}(task)
 	}
 }
 
 func (s *Scheduler) PurgeJobTasks(jobID string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	// Purge all active tasks
 	for taskID, task := range s.activeTasks {
@@ -289,6 +301,7 @@ func (s *Scheduler) PurgeJobTasks(jobID string) error {
 			delete(s.activeTasks, taskID)
 		}
 	}
+	s.mu.Unlock() // Release lock BEFORE draining channels to prevent deadlock
 
 	// Helper to filter tasks for a given job ID out of a queue channel.
 	// The safest way to filter a channel is to separate good ones and purge in place.

--- a/internal/coordinator/server.go
+++ b/internal/coordinator/server.go
@@ -40,7 +40,7 @@ func NewServer(scheduler *Scheduler, manager CloudManager, tracker *JobTracker, 
 
 	// Set the terminal failure callback
 	s.scheduler.OnTaskFailedPermanently = func(task *Task) {
-		log.Printf("[SERVER] Task %s for job %s failed permanently. Failing job.", task.ID, task.JobID)
+		log.Printf("[SERVER]: Task %s for job %s failed permanently. Failing job.", task.ID, task.JobID)
 		s.tracker.CancelJob(task.JobID)
 		s.scheduler.PurgeJobTasks(task.JobID)
 	}
@@ -65,9 +65,44 @@ func (s *Server) SubmitJob(ctx context.Context, req *pb.SubmitJobRequest) (*pb.S
 		jobID = uuid.New().String()
 	}
 
-	log.Printf("[COORDINATOR] Received SubmitJob request: %s", jobID)
+	log.Printf("[COORDINATOR]: Received SubmitJob request: %s", jobID)
 
 	var newJob Job
+
+	// Try to resolve general job info from dependencies if missing
+	numFrames := req.NumFrames
+	width := req.Width
+	height := req.Height
+
+	if (numFrames == 0 || width == 0 || height == 0) && len(req.DependsOn) > 0 {
+		for _, depID := range req.DependsOn {
+			depJob, err := s.tracker.GetJob(depID)
+			if err == nil {
+				depReq := depJob.GetOriginalReq()
+
+				// Validation: Ensure dimensions match if we already have a resolved width/height
+				if width > 0 && depReq.Width > 0 && width != depReq.Width {
+					return nil, fmt.Errorf("[ERROR] Dimension mismatch: dependency %s is %dx%d but previous deps are %dx%d", depID, depReq.Width, depReq.Height, width, height)
+				}
+
+				// Take the max frames found across all dependencies
+				if numFrames < depReq.NumFrames {
+					numFrames = depReq.NumFrames
+				}
+				// Take the largest dimensions found across all dependencies (if not already set)
+				if width == 0 {
+					width = depReq.Width
+				}
+				if height == 0 {
+					height = depReq.Height
+				}
+			}
+		}
+		// Update the request object so handlers use the inherited values
+		req.NumFrames = numFrames
+		req.Width = width
+		req.Height = height
+	}
 
 	// Route the job creation based on the user's requested payload
 	switch req.JobType.(type) {
@@ -76,7 +111,7 @@ func (s *Server) SubmitJob(ctx context.Context, req *pb.SubmitJobRequest) (*pb.S
 			JobID:        jobID,
 			Dependencies: req.DependsOn,
 			Status:       pb.GetJobStatusResponse_JOB_STATUS_UNSPECIFIED,
-			TotalTasks:   req.NumFrames, // Strictly one task per frame
+			TotalTasks:   numFrames, // Strictly one task per frame
 			OriginalReq:  req,
 		}
 	case *pb.SubmitJobRequest_CompositeJob:
@@ -84,11 +119,23 @@ func (s *Server) SubmitJob(ctx context.Context, req *pb.SubmitJobRequest) (*pb.S
 			JobID:        jobID,
 			Dependencies: req.DependsOn,
 			Status:       pb.GetJobStatusResponse_JOB_STATUS_UNSPECIFIED,
-			TotalFrames:  req.NumFrames,
+			TotalFrames:  numFrames,
 			OriginalReq:  req,
 		}
 	default:
-		return nil, fmt.Errorf("[ERROR] Unknown job type provided.")
+		return nil, fmt.Errorf("[ERROR]: Unknown job type provided.")
+	}
+
+	// Auto-append unique identifier to output path if it's the default to prevent collisions
+	currentPrefix := newJob.GetOutputPrefix()
+	if currentPrefix == "data/renders/" || currentPrefix == "data/renders" {
+		suffix := req.JobName
+		if suffix == "" || suffix == "skewer-job" || suffix == "skewer-composite" {
+			suffix = jobID[:8] // Use first 8 chars of UUID
+		}
+		newPrefix := filepath.Join(currentPrefix, suffix)
+		newJob.SetOutputPrefix(newPrefix)
+		log.Printf("[COORDINATOR] Auto-set output path for job %s: %s", jobID, newPrefix)
 	}
 
 	// Add the job to the JobTracker
@@ -96,8 +143,8 @@ func (s *Server) SubmitJob(ctx context.Context, req *pb.SubmitJobRequest) (*pb.S
 		return nil, err
 	}
 
-	// ONLY queue the tasks if there are NO dependencies!
-	if len(req.DependsOn) == 0 {
+	// ONLY queue the tasks if the job is ready (no pending dependencies)
+	if newJob.GetStatus() == pb.GetJobStatusResponse_JOB_STATUS_QUEUED {
 		var err error
 		switch req.JobType.(type) {
 		case *pb.SubmitJobRequest_RenderJob:
@@ -179,6 +226,12 @@ func (s *Server) GetWorkStream(req *pb.GetWorkStreamRequest, stream pb.Coordinat
 		return nil                            // Close stream, worker will reconnect and try again
 	}
 
+	// Update job status to RUNNING if it's currently QUEUED
+	if job.GetStatus() == pb.GetJobStatusResponse_JOB_STATUS_QUEUED {
+		log.Printf("[COORDINATOR]: Transitioning job %s to RUNNING state", task.JobID)
+		job.SetStatus(pb.GetJobStatusResponse_JOB_STATUS_RUNNING)
+	}
+
 	// Package task into the Protobuf format.
 	workPackage := &pb.WorkPackage{
 		JobId:   task.JobID,
@@ -248,6 +301,7 @@ func (s *Server) ReportTaskResult(ctx context.Context, req *pb.ReportTaskResultR
 	// Update completed Tasks for the job
 	job, err := s.tracker.GetJob(task.JobID)
 	if err != nil {
+		log.Printf("[ERROR]: Failed to get job %s for progress update: %v", task.JobID, err)
 		return &pb.ReportTaskResultResponse{Acknowledged: false}, err
 	}
 
@@ -255,45 +309,53 @@ func (s *Server) ReportTaskResult(ctx context.Context, req *pb.ReportTaskResultR
 	switch jobType := job.(type) {
 	case *RenderJob:
 		jobType.mu.Lock()
-
-		// Update completed tasks and check if job is complete
 		jobType.CompletedTasks++
+		log.Printf("[COORDINATOR] Job %s progress: %d/%d tasks complete", task.JobID, jobType.CompletedTasks, jobType.TotalTasks)
 		complete = jobType.CompletedTasks == jobType.TotalTasks
-
 		jobType.mu.Unlock()
 
 	case *CompositeJob:
 		jobType.mu.Lock()
 		jobType.CompletedFrames++
+		log.Printf("[COORDINATOR] Job %s progress: %d/%d frames complete", task.JobID, jobType.CompletedFrames, jobType.TotalFrames)
 		complete = jobType.CompletedFrames == jobType.TotalFrames
 		jobType.mu.Unlock()
 	}
 
 	// Queue downstream dependencies if job is complete
 	if complete {
+		log.Printf("[COORDINATOR]: Job %s is 100%% complete! Marking as COMPLETED.", job.ID())
 		job.SetStatus(pb.GetJobStatusResponse_JOB_STATUS_COMPLETED)
 
 		// Ask the tracker to safely update the math and report unlocked dependencies
 		unlockedJobs := s.tracker.UnlockDependencies(job.ID())
+		log.Printf("[COORDINATOR]: Unlocked %d downstream jobs for job %s", len(unlockedJobs), job.ID())
 
 		// Loop through whatever jobs just hit 0 dependencies and queue them
 		for _, newJob := range unlockedJobs {
-			// (We will eventually call s.handleCompositeJobSubmit here
-			// to actually queue the tasks for the newly unlocked job)
 			log.Printf("[COORDINATOR]: Job %s is fully unlocked and ready to queue!", newJob.ID())
 
 			// Type assert to figure out what kind of job just unlocked and queue it
 			req := newJob.GetOriginalReq()
+			var err error
 			switch typedJob := newJob.(type) {
 			case *RenderJob:
-				s.handleRenderJobSubmit(typedJob.ID(), req, req.GetRenderJob())
+				err = s.handleRenderJobSubmit(typedJob.ID(), req, req.GetRenderJob())
 			case *CompositeJob:
-				s.handleCompositeJobSubmit(typedJob.ID(), req, req.GetCompositeJob())
+				err = s.handleCompositeJobSubmit(typedJob.ID(), req, req.GetCompositeJob())
+			}
+			if err != nil {
+				log.Printf("[ERROR] Failed to queue unlocked job %s: %v", newJob.ID(), err)
 			}
 		}
 	}
 
 	return &pb.ReportTaskResultResponse{Acknowledged: true}, nil
+}
+
+func (s *Server) ReportTaskProgress(ctx context.Context, req *pb.ReportTaskProgressRequest) (*pb.ReportTaskProgressResponse, error) {
+	s.scheduler.UpdateHeartbeat(req.GetTaskId())
+	return &pb.ReportTaskProgressResponse{Acknowledged: true}, nil
 }
 
 // =====================================================================
@@ -312,12 +374,12 @@ func (s *Server) runCapacityManager(ctx context.Context) {
 			queueLengths := s.scheduler.GetQueueLengths()
 			activeCounts := s.scheduler.GetActiveTaskCounts()
 
-			// Determine global limit (default to 1 in local mode, 20 in cloud)
+			// Determine global limit (default to 4 in local mode, 20 in cloud)
 			limit := 20
 			if s.localStorageBase != "" {
-				limit = 1 // LOCAL MODE: Avoid blowing up laptop
+				limit = 4 // LOCAL MODE: Allow some parallelism by default
 			}
-			if val, err := strconv.Atoi(os.Getenv("MAX_WORKERS")); err == nil {
+			if val, err := strconv.Atoi(os.Getenv("MAX_WORKERS")); err == nil && val > 0 {
 				limit = val
 			}
 
@@ -375,55 +437,42 @@ func (s *Server) translateLocalPath(uri string) (string, error) {
 	// If the path is already absolute and starts with the host's data path, swap it.
 	if hostDataPath != "" && filepath.IsAbs(uri) && strings.HasPrefix(uri, hostDataPath) {
 		rel, _ := filepath.Rel(hostDataPath, uri)
-		// SECURITY: Clean the path and prevent traversal
-		cleanRel := filepath.Clean(rel)
-		if relativePathEscapesRoot(cleanRel) {
-			return "", fmt.Errorf("[ERROR]: Blocked dangerous traversal to uri: %s", uri) // Will propogate and be rejected by job submit
-		}
-
-		return filepath.Join(s.localStorageBase, cleanRel), nil
+		return filepath.Join(s.localStorageBase, filepath.Clean(rel)), nil
 	}
 
-	// Repo-relative paths (e.g. scenes/foo.json): workspace root is mounted at
-	// localStorageBase (/data in Kubernetes). Without this, workers see a bare
-	// relative path and resolve it from process CWD (/) and the task fails.
+	// Repo-relative paths: workspace root is mounted at localStorageBase (/data).
+	// We MUST join them to ensure we get /data/data/scenes/... etc.
 	if !filepath.IsAbs(uri) {
-		cleanRel := filepath.Clean(uri)
-		if cleanRel == "." || cleanRel == "" {
-			return "", fmt.Errorf("[ERROR]: Invalid empty relative path")
-		}
-		if relativePathEscapesRoot(cleanRel) {
-			return "", fmt.Errorf("[ERROR]: Blocked dangerous traversal to uri: %s", uri)
-		}
-		return filepath.Join(s.localStorageBase, cleanRel), nil
+		return filepath.Join(s.localStorageBase, filepath.Clean(uri)), nil
 	}
 
 	return uri, nil
 }
-
 func (s *Server) handleRenderJobSubmit(jobID string, req *pb.SubmitJobRequest, job *pb.RenderJob) error {
-	for frameID := int32(0); frameID < req.GetNumFrames(); frameID++ {
-		// Calculate uri prefixes
-		outputUriPrefix, err := s.translateLocalPath(job.GetOutputUriPrefix())
-		if err != nil {
-			return err
-		}
-		sceneUri, err := s.translateLocalPath(job.GetSceneUri())
-		if err != nil {
-			return err
-		}
+	outputUriPrefix, err := s.translateLocalPath(job.GetOutputUriPrefix())
+	if err != nil {
+		return err
+	}
+	sceneUri, err := s.translateLocalPath(job.GetSceneUri())
+	if err != nil {
+		return err
+	}
+
+	extension := ".exr"
+	if !job.GetEnableDeep() {
+		extension = ".png"
+	}
+
+	numFrames := int32(req.GetNumFrames())
+	tasks := make([]*pb.RenderTask, 0, numFrames)
+
+	for frameID := int32(0); frameID < numFrames; frameID++ {
 		if frameID == 0 {
 			log.Printf("[COORDINATOR] Scene path: raw=%q -> worker=%q", job.GetSceneUri(), sceneUri)
 		}
 
 		// Replace #### with padded frame ID if it exists in the scene URI
 		frameSceneUri := strings.ReplaceAll(sceneUri, "####", fmt.Sprintf("%04d", frameID+1))
-
-		// Some deep checking for the final file type extension
-		extension := ".exr"
-		if !job.GetEnableDeep() {
-			extension = ".png"
-		}
 
 		// This is the output uri for the frame
 		outputUri, err := url.JoinPath(outputUriPrefix, fmt.Sprintf("frame-%04d%s", frameID+1, extension))
@@ -446,38 +495,112 @@ func (s *Server) handleRenderJobSubmit(jobID string, req *pb.SubmitJobRequest, j
 			AdaptiveStep:   job.GetAdaptiveStep(),
 			MaxSamples:     job.GetMaxSamples(),
 		}
-
-		if _, err := s.scheduler.EnqueueTask(task, jobID, fmt.Sprint(frameID)); err != nil {
-			return fmt.Errorf("[ERROR]: Failed to enqueue render task for job %s frame %d (%w)", jobID, frameID, err)
-		}
+		tasks = append(tasks, task)
 	}
+
+	// Dispatch to scheduler asynchronously so the gRPC handler doesn't block if the queue is full
+	go func(tasks []*pb.RenderTask) {
+		for frameID, task := range tasks {
+			if _, err := s.scheduler.EnqueueTask(task, jobID, fmt.Sprint(frameID)); err != nil {
+				log.Printf("[ERROR]: Failed to enqueue render task for job %s frame %d (%v)", jobID, frameID, err)
+			}
+		}
+	}(tasks)
 
 	return nil
 }
 
 func (s *Server) handleCompositeJobSubmit(jobID string, req *pb.SubmitJobRequest, job *pb.CompositeJob) error {
+	log.Printf("[COORDINATOR]: Handling composite job submit for job %s", jobID)
 
 	outputUriPrefix, err := s.translateLocalPath(job.GetOutputUriPrefix())
 	if err != nil {
+		log.Printf("[ERROR]: Failed to translate output path for job %s: %v", jobID, err)
 		return err
 	}
+	log.Printf("[COORDINATOR]: Output URI Prefix for job %s: %s", jobID, outputUriPrefix)
 
-	for frameID := 0; frameID < int(req.GetNumFrames()); frameID++ {
+	// Resolve layers: prioritize explicit LayerUriPrefixes, fallback to DependsOn discovery
+	layerPrefixes := job.GetLayerUriPrefixes()
+	if len(layerPrefixes) == 0 {
+		log.Printf("[COORDINATOR]: No layers provided for job %s. Discovering from dependencies: %v", jobID, req.DependsOn)
+		for _, depID := range req.DependsOn {
+			depJob, err := s.tracker.GetJob(depID)
+			if err != nil {
+				log.Printf("[ERROR]: Failed to resolve dependency %s for composite discovery: %v", depID, err)
+				return fmt.Errorf("[ERROR]: Failed to resolve dependency %s for composite discovery: %w", depID, err)
+			}
+			prefix := depJob.GetOutputPrefix()
+			if prefix != "" {
+				// Resolve extension
+				ext := ".exr"
+				if rj, ok := depJob.(*RenderJob); ok && !rj.OriginalReq.GetRenderJob().GetEnableDeep() {
+					ext = ".png"
+				}
+				numLayerFrames := depJob.GetOriginalReq().GetNumFrames()
+				log.Printf("[COORDINATOR]: Discovered layer prefix from job %s: %s (Ext: %s, Frames: %d)", depID, prefix, ext, numLayerFrames)
+				layerPrefixes = append(layerPrefixes, fmt.Sprintf("%s|%s|%d", prefix, ext, numLayerFrames))
+			}
+		}
+	}
 
-		// gs://bucket/renders/smoke
-		originalPrefixes := job.GetLayerUriPrefixes()
+	if len(layerPrefixes) == 0 {
+		log.Printf("[ERROR]: Composite job %s has no input layers and no resolvable dependencies", jobID)
+		return fmt.Errorf("[ERROR]: Composite job %s has no input layers and no resolvable dependencies", jobID)
+	}
+
+	// Use inherited/provided dimensions
+	width := req.GetWidth()
+	height := req.GetHeight()
+	log.Printf("[COORDINATOR]: Composite job %s dimensions: %dx%d", jobID, width, height)
+
+	numFrames := int(req.GetNumFrames())
+	log.Printf("[COORDINATOR]: Enqueuing %d composite tasks for job %s", numFrames, jobID)
+
+	// Pre-resolve prefixes outside of the massive frame loop to prevent redundant allocations and GetEnv calls
+	type LayerDef struct {
+		Prefix    string
+		Ext       string
+		NumFrames int
+	}
+	translatedPrefixes := make([]LayerDef, len(layerPrefixes))
+
+	for idx, entry := range layerPrefixes {
+		parts := strings.Split(entry, "|")
+		uriPrefix := parts[0]
+		extension := ".exr"
+		numLayerFrames := 1
+		if len(parts) > 1 {
+			extension = parts[1]
+		}
+		if len(parts) > 2 {
+			if parsed, err := strconv.Atoi(parts[2]); err == nil {
+				numLayerFrames = parsed
+			}
+		}
+		translatedPrefix, err := s.translateLocalPath(uriPrefix)
+		if err != nil {
+			return err
+		}
+		translatedPrefixes[idx] = LayerDef{Prefix: translatedPrefix, Ext: extension, NumFrames: numLayerFrames}
+	}
+
+	tasks := make([]*pb.CompositeTask, 0, numFrames)
+
+	for frameID := 0; frameID < numFrames; frameID++ {
 
 		// Create a fresh slice for THIS specific frame task
-		frameLayerUris := make([]string, len(originalPrefixes))
+		frameLayerUris := make([]string, len(translatedPrefixes))
 
-		// Clean all the uri prefixes for the layers and store them as full uris in new list
-		for idx, uriPrefix := range originalPrefixes {
-			translatedPrefix, err := s.translateLocalPath(uriPrefix)
-			if err != nil {
-				return err
+		for idx, p := range translatedPrefixes {
+			layerTargetFrame := frameID
+			if p.NumFrames == 1 {
+				layerTargetFrame = 0
+			} else if layerTargetFrame >= p.NumFrames {
+				layerTargetFrame = p.NumFrames - 1
 			}
 
-			fullLayerUri, err := url.JoinPath(translatedPrefix, fmt.Sprintf("frame-%04d.exr", frameID+1))
+			fullLayerUri, err := url.JoinPath(p.Prefix, fmt.Sprintf("frame-%04d%s", layerTargetFrame+1, p.Ext))
 			if err != nil {
 				return err
 			}
@@ -493,14 +616,22 @@ func (s *Server) handleCompositeJobSubmit(jobID string, req *pb.SubmitJobRequest
 		task := &pb.CompositeTask{
 			LayerUris: frameLayerUris,
 
-			Width:  req.GetWidth(),
-			Height: req.GetHeight(),
+			Width:  width,
+			Height: height,
 
 			OutputUri: finalOutputUri,
 		}
-		s.scheduler.EnqueueTask(task, jobID, fmt.Sprint(frameID))
-
+		tasks = append(tasks, task)
 	}
+
+	// Dispatch to scheduler asynchronously so the gRPC handler doesn't block if the queue is full
+	go func(tasks []*pb.CompositeTask) {
+		for frameID, task := range tasks {
+			if _, err := s.scheduler.EnqueueTask(task, jobID, fmt.Sprint(frameID)); err != nil {
+				log.Printf("[ERROR]: Failed to enqueue composite task for job %s frame %d (%v)", jobID, frameID, err)
+			}
+		}
+	}(tasks)
 
 	return nil
 }

--- a/loom/apps/worker/main.cc
+++ b/loom/apps/worker/main.cc
@@ -99,7 +99,8 @@ void RunLoomWorker(const std::string& coordinator_addr) {
                     std::vector<float> z_offsets(inputFiles.size() > 1 ? inputFiles.size() - 1 : 0,
                                                  0.0f);
                     Options opts = {
-                        inputFiles, z_offsets,
+                        inputFiles,
+                        z_offsets,
                         "",  // coordinator handles output prefixing and parsing
                     };
 

--- a/loom/apps/worker/main.cc
+++ b/loom/apps/worker/main.cc
@@ -1,5 +1,6 @@
 #include <grpcpp/grpcpp.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
@@ -14,9 +15,22 @@
 #include "proto/coordinator/v1/coordinator.grpc.pb.h"
 #include "proto/coordinator/v1/coordinator.pb.h"
 
+struct HeartbeatGuard {
+    std::atomic<bool>& active;
+    std::thread& th;
+    ~HeartbeatGuard() {
+        active.store(false);
+        if (th.joinable()) {
+            th.join();
+        }
+    }
+};
+
 using api::proto::coordinator::v1::CompositeTask;
 using api::proto::coordinator::v1::CoordinatorService;
 using api::proto::coordinator::v1::GetWorkStreamRequest;
+using api::proto::coordinator::v1::ReportTaskProgressRequest;
+using api::proto::coordinator::v1::ReportTaskProgressResponse;
 using api::proto::coordinator::v1::ReportTaskResultRequest;
 using api::proto::coordinator::v1::ReportTaskResultResponse;
 using api::proto::coordinator::v1::WorkPackage;
@@ -82,10 +96,11 @@ void RunLoomWorker(const std::string& coordinator_addr) {
                         std::cout << "  - " << uri << "\n";
                     }
 
+                    std::vector<float> z_offsets(inputFiles.size() > 1 ? inputFiles.size() - 1 : 0,
+                                                 0.0f);
                     Options opts = {
-                        inputFiles,
-                        std::vector<float>{0},  // TODO: collect real input_z_offsets
-                        "",                     // coordinator handles output prefixing and parsing
+                        inputFiles, z_offsets,
+                        "",  // coordinator handles output prefixing and parsing
                     };
 
                     // Populate image info using opts
@@ -99,12 +114,42 @@ void RunLoomWorker(const std::string& coordinator_addr) {
                     // Process and write image in different formats
                     std::cout << "[Loom] -> Writing result to: " << output_uri << "\n";
 
+                    // 1) Spawn heartbeat thread before expensive compositing begins
+                    std::atomic<bool> heartbeat_active(true);
+                    std::thread heartbeat_thread([&]() {
+                        while (heartbeat_active.load()) {
+                            for (int i = 0; i < 30;
+                                 ++i) {  // Sleep for 30s but check exit condition every second
+                                if (!heartbeat_active.load()) return;
+                                std::this_thread::sleep_for(std::chrono::seconds(1));
+                            }
+
+                            ClientContext hb_context;
+                            ReportTaskProgressRequest hb_req;
+                            hb_req.set_task_id(package.task_id());
+                            hb_req.set_worker_id(worker_id);
+                            hb_req.set_progress_percent(
+                                0.0);  // Polling real progress can go here later
+
+                            ReportTaskProgressResponse hb_res;
+                            stub->ReportTaskProgress(&hb_context, hb_req, &hb_res);
+                        }
+                    });
+                    HeartbeatGuard hb_guard{heartbeat_active, heartbeat_thread};
+
+                    int real_width = task.width();
+                    int real_height = task.height();
+                    if ((real_width == 0 || real_height == 0) && !imagesInfo.empty()) {
+                        real_width = imagesInfo[0]->width();
+                        real_height = imagesInfo[0]->height();
+                    }
+
                     // Write deep EXR (handles if deep output is wanted)
-                    std::vector<float> finalImage = deep_compositor::ProcessAllEXR(
-                        opts, task.height(), task.width(), imagesInfo);
+                    std::vector<float> finalImage =
+                        deep_compositor::ProcessAllEXR(opts, real_height, real_width, imagesInfo);
                     // Writes flat outputs if needed
                     exrio::WriteFlatOutputs(finalImage, output_uri, opts.flat_output,
-                                            opts.png_output, task.width(), task.height());
+                                            opts.png_output, real_width, real_height);
 
                     std::cout << "[Loom] -> Engine Composite execution completed.\n";
 

--- a/loom/src/deep_compositor.cc
+++ b/loom/src/deep_compositor.cc
@@ -105,7 +105,9 @@ void LoaderWorker(int start_row, int end_row, PipelineContext& ctx) {
                                                        sampleStride));
 
             file.setFrameBuffer(frameBuffer);
-            file.readPixels(load_y, load_y);
+            int exr_y = load_y + ctx.images_info[i]->min_y();
+            file.readPixelSampleCounts(exr_y, exr_y);
+            file.readPixels(exr_y, exr_y);
         }
 
         ctx.row_status[load_y].store(LOADED);
@@ -199,6 +201,12 @@ void WriterWorker(int start_row, int end_row, PipelineContext& ctx) {
 
 std::vector<float> ProcessAllEXR(const Options& opts, int height, int width,
                                  std::vector<std::unique_ptr<DeepInfo>>& images_info) {
+    if ((width == 0 || height == 0) && !images_info.empty()) {
+        width = images_info[0]->width();
+        height = images_info[0]->height();
+        printf("[Loom] Inherited dimensions from first input: %dx%d\n", width, height);
+    }
+
     const int window_size = 48;
     int num_files = opts.input_files.size();
 

--- a/loom/src/deep_info.h
+++ b/loom/src/deep_info.h
@@ -5,14 +5,9 @@
 #include <OpenEXR/ImfDeepScanLineInputFile.h>  // For reading deep EXR files
 #include <OpenEXR/ImfMultiPartInputFile.h>
 
-#include <algorithm>
-#include <cmath>
-#include <limits>
-#include <stdexcept>
 #include <vector>
 
 namespace deep_compositor {
-
 class DeepInfo {
   public:
     DeepInfo();
@@ -21,6 +16,8 @@ class DeepInfo {
     {
         // Once the file is open, we extract the metadata (width/height)
         Imath::Box2i dw = file_.header().dataWindow();
+        min_x_ = dw.min.x;
+        min_y_ = dw.min.y;
         width_ = dw.max.x - dw.min.x + 1;
         height_ = dw.max.y - dw.min.y + 1;
         printf("Loaded Deep EXR: %s (%dx%d)\n", filename.c_str(), width_, height_);
@@ -31,6 +28,8 @@ class DeepInfo {
 
     int width() const { return width_; }
     int height() const { return height_; }
+    int min_x() const { return min_x_; }
+    int min_y() const { return min_y_; }
     // bool isDeep() const { return isDeep_; }
 
     Imf::DeepScanLineInputFile& GetFile() { return file_; }
@@ -58,13 +57,10 @@ class DeepInfo {
         // Resize buffer to fit one row of integers
         temp_sample_counts.resize(width_);
 
-        Imath::Box2i dw = file_.header().dataWindow();
-        int minX = dw.min.x;
-
         Imf::DeepFrameBuffer countBuffer;
         // We point to the start of our vector, but tell OpenEXR
-        // that this memory represents pixel (minX, y)
-        char* base = (char*)(temp_sample_counts.data()) - (minX * sizeof(unsigned int));
+        // that this memory represents pixel (min_x_, y)
+        char* base = (char*)(temp_sample_counts.data()) - (min_x_ * sizeof(unsigned int));
         // Note: We don't subtract y because we only read one row (y, y)
 
         countBuffer.insertSampleCountSlice(Imf::Slice(Imf::UINT, base,
@@ -73,7 +69,8 @@ class DeepInfo {
                                                       ));
 
         file_.setFrameBuffer(countBuffer);
-        file_.readPixelSampleCounts(y, y);
+        int exr_y = y + min_y_;
+        file_.readPixelSampleCounts(exr_y, exr_y);
     }
 
     // 2. Explicitly forbid Copying (Since the EXR file handle can't be duplicated)
@@ -86,6 +83,8 @@ class DeepInfo {
   private:
     int width_;
     int height_;
+    int min_x_;
+    int min_y_;
 
     std::vector<unsigned int> temp_sample_counts;
 

--- a/skewer/apps/worker/main.cc
+++ b/skewer/apps/worker/main.cc
@@ -137,23 +137,26 @@ void RunSkewerWorker(const std::string& coordinator_addr) {
                     session.Options().integrator_config.adaptive_step = task.adaptive_step();
                 }
 
-                std::cout << "[SKEWER]: Rendering " << session.Options().image_config.width << "x" 
-                          << session.Options().image_config.height << " (Threads: " << task_threads << ")\n";
+                std::cout << "[SKEWER]: Rendering " << session.Options().image_config.width << "x"
+                          << session.Options().image_config.height << " (Threads: " << task_threads
+                          << ")\n";
 
                 // 1) Spawn heartbeat thread before rendering begins
                 std::atomic<bool> heartbeat_active(true);
                 std::thread heartbeat_thread([&]() {
                     while (heartbeat_active.load()) {
-                        for (int i = 0; i < 30; ++i) { // Sleep for 30s but check exit condition every second
+                        for (int i = 0; i < 30;
+                             ++i) {  // Sleep for 30s but check exit condition every second
                             if (!heartbeat_active.load()) return;
                             std::this_thread::sleep_for(std::chrono::seconds(1));
                         }
-                        
+
                         ClientContext hb_context;
                         ReportTaskProgressRequest hb_req;
                         hb_req.set_task_id(package.task_id());
                         hb_req.set_worker_id(worker_id);
-                        hb_req.set_progress_percent(0.0); // Polling real progress can go here later
+                        hb_req.set_progress_percent(
+                            0.0);  // Polling real progress can go here later
 
                         ReportTaskProgressResponse hb_res;
                         stub->ReportTaskProgress(&hb_context, hb_req, &hb_res);

--- a/skewer/apps/worker/main.cc
+++ b/skewer/apps/worker/main.cc
@@ -1,5 +1,6 @@
 #include <grpcpp/grpcpp.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
@@ -13,9 +14,22 @@
 #include "session/render_options.h"
 #include "session/render_session.h"
 
+struct HeartbeatGuard {
+    std::atomic<bool>& active;
+    std::thread& th;
+    ~HeartbeatGuard() {
+        active.store(false);
+        if (th.joinable()) {
+            th.join();
+        }
+    }
+};
+
 using api::proto::coordinator::v1::CoordinatorService;
 using api::proto::coordinator::v1::GetWorkStreamRequest;
 using api::proto::coordinator::v1::RenderTask;
+using api::proto::coordinator::v1::ReportTaskProgressRequest;
+using api::proto::coordinator::v1::ReportTaskProgressResponse;
 using api::proto::coordinator::v1::ReportTaskResultRequest;
 using api::proto::coordinator::v1::ReportTaskResultResponse;
 using api::proto::coordinator::v1::WorkPackage;
@@ -123,10 +137,31 @@ void RunSkewerWorker(const std::string& coordinator_addr) {
                     session.Options().integrator_config.adaptive_step = task.adaptive_step();
                 }
 
-                std::cout << "[SKEWER]: Rendering " << task.width() << "x" << task.height()
-                          << " (Threads: " << task_threads << ")\n";
+                std::cout << "[SKEWER]: Rendering " << session.Options().image_config.width << "x" 
+                          << session.Options().image_config.height << " (Threads: " << task_threads << ")\n";
 
-                // Now render the task
+                // 1) Spawn heartbeat thread before rendering begins
+                std::atomic<bool> heartbeat_active(true);
+                std::thread heartbeat_thread([&]() {
+                    while (heartbeat_active.load()) {
+                        for (int i = 0; i < 30; ++i) { // Sleep for 30s but check exit condition every second
+                            if (!heartbeat_active.load()) return;
+                            std::this_thread::sleep_for(std::chrono::seconds(1));
+                        }
+                        
+                        ClientContext hb_context;
+                        ReportTaskProgressRequest hb_req;
+                        hb_req.set_task_id(package.task_id());
+                        hb_req.set_worker_id(worker_id);
+                        hb_req.set_progress_percent(0.0); // Polling real progress can go here later
+
+                        ReportTaskProgressResponse hb_res;
+                        stub->ReportTaskProgress(&hb_context, hb_req, &hb_res);
+                    }
+                });
+                HeartbeatGuard hb_guard{heartbeat_active, heartbeat_thread};
+
+                // Now render the task (blocking)
                 session.Render();
                 session.Save();
 

--- a/skewer/apps/worker/main.cc
+++ b/skewer/apps/worker/main.cc
@@ -1,5 +1,5 @@
-#include <grpcpp/grpcpp.h>
 #include <coordinator_worker/worker_loop.h>
+#include <grpcpp/grpcpp.h>
 
 #include <atomic>
 #include <chrono>


### PR DESCRIPTION
Our cloud pipeline was only able to do render jobs with the `submit` command. This PR separates this command into `render` and `composite` to also utilize loom's compositing features. Jobs will also follow a dependency graph with the built-in DAG in the Job Tracker. 

Transitioning from render jobs to compositing jobs requires some reconciliation between frame numbers and dimension sizes so some assumptions must be made. The renders being composited must have the same dimensions. A pipelined composite job that comes after its dependencies will inherit the dimensions of its predecessors. This can only work if images are rendered with the `--deep` flag

EDIT: I'm noticing that sometimes Kubernetes kills without warning so while we're at it, it would make sense to add heartbeats. This would fix any synchronous sweep deadlocks.

Closes #139 and #141 