### PR TITLE
[refactor] use quaternions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,15 @@ renders/
 *.exr
 *.ppm
 
+# Terraform
+*.tfstate
+*.tfstate.backup
+.terraform/
+
+# Go binaries
+/coordinator
+/cli
+
 .claude/
 opencode.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ renders/
 *.tfstate
 *.tfstate.backup
 .terraform/
+terraform.tfvars
 
 # Go binaries
 /coordinator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,3 +44,15 @@ endif()
 if(SKEWER_COMBINED_BUILD_SKEWER)
     add_subdirectory(skewer)
 endif()
+
+# FetchContent deps (e.g. googletest) inherit directory compile options including -Werror.
+# Do not treat their warnings as build failures.
+if(BUILD_TESTING)
+    foreach(_skewer_3p_tgt IN ITEMS gtest gtest_main gmock gmock_main)
+        if(TARGET ${_skewer_3p_tgt})
+            if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+                target_compile_options(${_skewer_3p_tgt} PRIVATE -Wno-error)
+            endif()
+        endif()
+    endforeach()
+endif()

--- a/skewer/src/core/math/quat.h
+++ b/skewer/src/core/math/quat.h
@@ -38,7 +38,8 @@ inline float QuatDot(const Quat& a, const Quat& b) {
     return a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z;
 }
 
-// Rotation order matches legacy RotateEulerYXZ: apply Y, then X, then Z (radians).
+// Intrinsic YXZ: first rotate around local Y, then local X, then local Z.
+// Produces the same matrix as Three.js `rotation.order = "YXZ"`: R = Ry * Rx * Rz.
 inline Quat QuatFromEulerYXZ(float rx_rad, float ry_rad, float rz_rad) {
     float hx = 0.5f * rx_rad;
     float hy = 0.5f * ry_rad;
@@ -52,7 +53,7 @@ inline Quat QuatFromEulerYXZ(float rx_rad, float ry_rad, float rz_rad) {
     Quat qy{cy, 0.0f, sy, 0.0f};
     Quat qz{cz, 0.0f, 0.0f, sz};
 
-    return QuatMultiply(QuatMultiply(qz, qx), qy);
+    return QuatMultiply(QuatMultiply(qy, qx), qz);
 }
 
 inline Vec3 QuatRotate(const Quat& q, const Vec3& v) {

--- a/skewer/src/core/math/quat.h
+++ b/skewer/src/core/math/quat.h
@@ -1,0 +1,90 @@
+#ifndef SKWR_CORE_MATH_QUAT_H_
+#define SKWR_CORE_MATH_QUAT_H_
+
+#include <cmath>
+
+#include "core/math/vec3.h"
+
+namespace skwr {
+
+struct Quat {
+    float w = 1.0f;
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+inline Quat QuatNormalize(const Quat& q) {
+    float len = std::sqrt(q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z);
+    if (len <= 0.0f) {
+        return Quat{1.0f, 0.0f, 0.0f, 0.0f};
+    }
+    float inv = 1.0f / len;
+    return Quat{q.w * inv, q.x * inv, q.y * inv, q.z * inv};
+}
+
+inline Quat QuatConjugate(const Quat& q) { return Quat{q.w, -q.x, -q.y, -q.z}; }
+
+inline Quat QuatMultiply(const Quat& a, const Quat& b) {
+    return Quat{
+        a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z,
+        a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+        a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+        a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
+    };
+}
+
+inline float QuatDot(const Quat& a, const Quat& b) {
+    return a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+// Rotation order matches legacy RotateEulerYXZ: apply Y, then X, then Z (radians).
+inline Quat QuatFromEulerYXZ(float rx_rad, float ry_rad, float rz_rad) {
+    float hx = 0.5f * rx_rad;
+    float hy = 0.5f * ry_rad;
+    float hz = 0.5f * rz_rad;
+
+    float cx = std::cos(hx), sx = std::sin(hx);
+    float cy = std::cos(hy), sy = std::sin(hy);
+    float cz = std::cos(hz), sz = std::sin(hz);
+
+    Quat qx{cx, sx, 0.0f, 0.0f};
+    Quat qy{cy, 0.0f, sy, 0.0f};
+    Quat qz{cz, 0.0f, 0.0f, sz};
+
+    return QuatMultiply(QuatMultiply(qz, qx), qy);
+}
+
+inline Vec3 QuatRotate(const Quat& q, const Vec3& v) {
+    Vec3 qv(q.x, q.y, q.z);
+    return v + 2.0f * Cross(qv, Cross(qv, v) + q.w * v);
+}
+
+inline Quat QuatSlerp(const Quat& a, const Quat& b, float t) {
+    Quat bn = b;
+    float d = QuatDot(a, bn);
+    if (d < 0.0f) {
+        bn = Quat{-bn.w, -bn.x, -bn.y, -bn.z};
+        d = -d;
+    }
+
+    if (d > 0.9995f) {
+        Quat r{a.w + t * (bn.w - a.w), a.x + t * (bn.x - a.x), a.y + t * (bn.y - a.y),
+               a.z + t * (bn.z - a.z)};
+        return QuatNormalize(r);
+    }
+
+    float theta_0 = std::acos(d);
+    float theta = theta_0 * t;
+    float sin_theta = std::sin(theta);
+    float sin_theta_0 = std::sin(theta_0);
+
+    float s0 = std::cos(theta) - d * sin_theta / sin_theta_0;
+    float s1 = sin_theta / sin_theta_0;
+    return Quat{a.w * s0 + bn.w * s1, a.x * s0 + bn.x * s1, a.y * s0 + bn.y * s1,
+                a.z * s0 + bn.z * s1};
+}
+
+}  // namespace skwr
+
+#endif  // SKWR_CORE_MATH_QUAT_H_

--- a/skewer/src/core/math/quat.h
+++ b/skewer/src/core/math/quat.h
@@ -69,6 +69,8 @@ inline Quat QuatSlerp(const Quat& a, const Quat& b, float t) {
         d = -d;
     }
 
+    d = std::fmin(1.0f, std::fmax(0.0f, d));
+
     if (d > 0.9995f) {
         Quat r{a.w + t * (bn.w - a.w), a.x + t * (bn.x - a.x), a.y + t * (bn.y - a.y),
                a.z + t * (bn.z - a.z)};
@@ -76,10 +78,15 @@ inline Quat QuatSlerp(const Quat& a, const Quat& b, float t) {
     }
 
     float theta_0 = std::acos(d);
+    float sin_theta_0 = std::sin(theta_0);
+    if (sin_theta_0 <= 1e-6f) {
+        Quat r{a.w + t * (bn.w - a.w), a.x + t * (bn.x - a.x), a.y + t * (bn.y - a.y),
+               a.z + t * (bn.z - a.z)};
+        return QuatNormalize(r);
+    }
+
     float theta = theta_0 * t;
     float sin_theta = std::sin(theta);
-    float sin_theta_0 = std::sin(theta_0);
-
     float s0 = std::cos(theta) - d * sin_theta / sin_theta_0;
     float s1 = sin_theta / sin_theta_0;
     return Quat{a.w * s0 + bn.w * s1, a.x * s0 + bn.x * s1, a.y * s0 + bn.y * s1,

--- a/skewer/src/core/math/transform.h
+++ b/skewer/src/core/math/transform.h
@@ -1,66 +1,63 @@
 #ifndef SKWR_CORE_MATH_TRANSFORM_H_
 #define SKWR_CORE_MATH_TRANSFORM_H_
 
-#include <cmath>
-#include <vector>
-
 #include "core/math/constants.h"
+#include "core/math/quat.h"
 #include "core/math/utils.h"
 #include "core/math/vec3.h"
 
 namespace skwr {
 
-// Rotate a point by Euler angles (in radians), applied in Y-X-Z order.
-inline Vec3 RotateEulerYXZ(const Vec3& p, float rx, float ry, float rz) {
-    // Y rotation (yaw)
-    float cy = std::cos(ry), sy = std::sin(ry);
-    Vec3 r1(cy * p.x() + sy * p.z(), p.y(), -sy * p.x() + cy * p.z());
+struct TRS {
+    Vec3 translation{0.0f, 0.0f, 0.0f};
+    Quat rotation{};
+    Vec3 scale{1.0f, 1.0f, 1.0f};
+};
 
-    // X rotation (pitch)
-    float cx = std::cos(rx), sx = std::sin(rx);
-    Vec3 r2(r1.x(), cx * r1.y() - sx * r1.z(), sx * r1.y() + cx * r1.z());
-
-    // Z rotation (roll)
-    float cz = std::cos(rz), sz = std::sin(rz);
-    return Vec3(cz * r2.x() - sz * r2.y(), sz * r2.x() + cz * r2.y(), r2.z());
-}
-
-// Apply Scale -> Rotate -> Translate to a set of vertex positions.
-// Rotation angles are in degrees. Scale is per-axis.
-inline void ApplyTransform(std::vector<Vec3>& vertices, const Vec3& translate,
-                           const Vec3& rotate_deg, const Vec3& scale) {
+inline TRS TRSFromEuler(const Vec3& translate, const Vec3& rotate_deg, const Vec3& scale) {
     float rx = DegreesToRadians(rotate_deg.x());
     float ry = DegreesToRadians(rotate_deg.y());
     float rz = DegreesToRadians(rotate_deg.z());
-
-    bool has_rotation = (rx != 0.0f || ry != 0.0f || rz != 0.0f);
-
-    for (auto& v : vertices) {
-        // Scale
-        v = Vec3(v.x() * scale.x(), v.y() * scale.y(), v.z() * scale.z());
-
-        // Rotate
-        if (has_rotation) {
-            v = RotateEulerYXZ(v, rx, ry, rz);
-        }
-
-        // Translate
-        v = v + translate;
-    }
+    return TRS{translate, QuatNormalize(QuatFromEulerYXZ(rx, ry, rz)), scale};
 }
 
-// Apply the same rotation to normal vectors (no scale/translate).
-// Normals need to be re-normalized after rotation.
-inline void ApplyRotationToNormals(std::vector<Vec3>& normals, const Vec3& rotate_deg) {
-    float rx = DegreesToRadians(rotate_deg.x());
-    float ry = DegreesToRadians(rotate_deg.y());
-    float rz = DegreesToRadians(rotate_deg.z());
+inline TRS Compose(const TRS& parent, const TRS& child) {
+    TRS out{};
+    out.scale = parent.scale * child.scale;
+    out.rotation = QuatNormalize(QuatMultiply(parent.rotation, child.rotation));
+    Vec3 st =
+        Vec3(child.translation.x() * parent.scale.x(), child.translation.y() * parent.scale.y(),
+             child.translation.z() * parent.scale.z());
+    out.translation = parent.translation + QuatRotate(parent.rotation, st);
+    return out;
+}
 
-    if (rx == 0.0f && ry == 0.0f && rz == 0.0f) return;
+inline Vec3 TRSApplyPoint(const TRS& trs, const Vec3& p) {
+    Vec3 scaled = trs.scale * p;
+    return trs.translation + QuatRotate(trs.rotation, scaled);
+}
 
-    for (auto& n : normals) {
-        n = Normalize(RotateEulerYXZ(n, rx, ry, rz));
+inline Vec3 TRSApplyNormal(const TRS& trs, const Vec3& n) {
+    Vec3 inv_scaled(n.x() / trs.scale.x(), n.y() / trs.scale.y(), n.z() / trs.scale.z());
+    return Normalize(QuatRotate(trs.rotation, inv_scaled));
+}
+
+inline bool TRSIsIdentity(const TRS& trs) {
+    if (std::fabs(trs.translation.x()) > Numeric::kNearZeroEpsilon ||
+        std::fabs(trs.translation.y()) > Numeric::kNearZeroEpsilon ||
+        std::fabs(trs.translation.z()) > Numeric::kNearZeroEpsilon) {
+        return false;
     }
+    if (std::fabs(trs.scale.x() - 1.0f) > Numeric::kNearZeroEpsilon ||
+        std::fabs(trs.scale.y() - 1.0f) > Numeric::kNearZeroEpsilon ||
+        std::fabs(trs.scale.z() - 1.0f) > Numeric::kNearZeroEpsilon) {
+        return false;
+    }
+    Quat rq = QuatNormalize(trs.rotation);
+    return std::fabs(rq.w - 1.0f) <= Numeric::kNearZeroEpsilon &&
+           std::fabs(rq.x) <= Numeric::kNearZeroEpsilon &&
+           std::fabs(rq.y) <= Numeric::kNearZeroEpsilon &&
+           std::fabs(rq.z) <= Numeric::kNearZeroEpsilon;
 }
 
 }  // namespace skwr

--- a/skewer/src/core/math/transform.h
+++ b/skewer/src/core/math/transform.h
@@ -1,6 +1,8 @@
 #ifndef SKWR_CORE_MATH_TRANSFORM_H_
 #define SKWR_CORE_MATH_TRANSFORM_H_
 
+#include <cmath>
+
 #include "core/math/constants.h"
 #include "core/math/quat.h"
 #include "core/math/utils.h"
@@ -38,7 +40,12 @@ inline Vec3 TRSApplyPoint(const TRS& trs, const Vec3& p) {
 }
 
 inline Vec3 TRSApplyNormal(const TRS& trs, const Vec3& n) {
-    Vec3 inv_scaled(n.x() / trs.scale.x(), n.y() / trs.scale.y(), n.z() / trs.scale.z());
+    float sx = trs.scale.x(), sy = trs.scale.y(), sz = trs.scale.z();
+    if (std::fabs(sx) < Numeric::kNearZeroEpsilon || std::fabs(sy) < Numeric::kNearZeroEpsilon ||
+        std::fabs(sz) < Numeric::kNearZeroEpsilon) {
+        return Normalize(QuatRotate(trs.rotation, n));
+    }
+    Vec3 inv_scaled(n.x() / sx, n.y() / sy, n.z() / sz);
     return Normalize(QuatRotate(trs.rotation, inv_scaled));
 }
 
@@ -54,10 +61,9 @@ inline bool TRSIsIdentity(const TRS& trs) {
         return false;
     }
     Quat rq = QuatNormalize(trs.rotation);
-    return std::fabs(rq.w - 1.0f) <= Numeric::kNearZeroEpsilon &&
-           std::fabs(rq.x) <= Numeric::kNearZeroEpsilon &&
-           std::fabs(rq.y) <= Numeric::kNearZeroEpsilon &&
-           std::fabs(rq.z) <= Numeric::kNearZeroEpsilon;
+    float imag_len = std::sqrt(rq.x * rq.x + rq.y * rq.y + rq.z * rq.z);
+    float angle = 2.0f * std::atan2(imag_len, std::fabs(rq.w));
+    return angle <= 1e-5f;
 }
 
 }  // namespace skwr

--- a/skewer/src/io/scene_loader.cc
+++ b/skewer/src/io/scene_loader.cc
@@ -336,7 +336,8 @@ static void ParseObj(const json& obj, const MaterialMap& mat_map, Scene& scene, 
     size_t mesh_count_before = scene.MeshCount();
 
     // Load OBJ — when auto_fit is true, the loader normalizes to 2-unit cube.
-    // We pass Vec3(1,1,1) as scale here because we handle scaling ourselves via ApplyTransform.
+    // We pass Vec3(1,1,1) as scale here because we apply TRS (scale → rotate → translate) after
+    // load.
     if (!LoadOBJ(filepath, scene, Vec3(1.0f, 1.0f, 1.0f), auto_fit)) {
         throw std::runtime_error("Object at index " + std::to_string(index) +
                                  ": failed to load OBJ file '" + filepath + "'");
@@ -373,18 +374,17 @@ static void ParseObj(const json& obj, const MaterialMap& mat_map, Scene& scene, 
         }
     }
 
-    // Apply transform (Scale -> Rotate -> Translate) to all newly added meshes
-    bool has_transform =
-        (obj_scale.x() != 1.0f || obj_scale.y() != 1.0f || obj_scale.z() != 1.0f ||
-         rotate_deg.x() != 0.0f || rotate_deg.y() != 0.0f || rotate_deg.z() != 0.0f ||
-         translate.x() != 0.0f || translate.y() != 0.0f || translate.z() != 0.0f);
-
-    if (has_transform) {
+    TRS trs = TRSFromEuler(translate, rotate_deg, obj_scale);
+    if (!TRSIsIdentity(trs)) {
         for (size_t i = mesh_count_before; i < scene.MeshCount(); i++) {
             Mesh& mesh = scene.GetMutableMesh(static_cast<uint32_t>(i));
-            ApplyTransform(mesh.p, translate, rotate_deg, obj_scale);
+            for (Vec3& v : mesh.p) {
+                v = TRSApplyPoint(trs, v);
+            }
             if (!mesh.n.empty()) {
-                ApplyRotationToNormals(mesh.n, rotate_deg);
+                for (Vec3& n : mesh.n) {
+                    n = TRSApplyNormal(trs, n);
+                }
             }
         }
     }

--- a/skewer/tests/CMakeLists.txt
+++ b/skewer/tests/CMakeLists.txt
@@ -15,6 +15,8 @@ set(TEST_SOURCES
 add_executable(unit_tests
     unit/test_image_io.cc
     unit/test_film_alpha.cc
+    unit/test_quat.cc
+    unit/test_trs.cc
     ${TEST_SOURCES}
 )
 

--- a/skewer/tests/unit/test_quat.cc
+++ b/skewer/tests/unit/test_quat.cc
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "core/math/constants.h"
+#include "core/math/quat.h"
+#include "core/math/vec3.h"
+
+namespace {
+
+skwr::Vec3 RotateEulerYXZRef(const skwr::Vec3& p, float rx, float ry, float rz) {
+    float cy = std::cos(ry), sy = std::sin(ry);
+    skwr::Vec3 r1(cy * p.x() + sy * p.z(), p.y(), -sy * p.x() + cy * p.z());
+    float cx = std::cos(rx), sx = std::sin(rx);
+    skwr::Vec3 r2(r1.x(), cx * r1.y() - sx * r1.z(), sx * r1.y() + cx * r1.z());
+    float cz = std::cos(rz), sz = std::sin(rz);
+    return skwr::Vec3(cz * r2.x() - sz * r2.y(), sz * r2.x() + cz * r2.y(), r2.z());
+}
+
+}  // namespace
+
+namespace skwr {
+
+TEST(Quat, EulerMatchesLegacyYXZ) {
+    const Vec3 p(0.3f, -1.2f, 2.7f);
+    const float rx = 0.41f;
+    const float ry = -0.73f;
+    const float rz = 1.05f;
+
+    Quat q = QuatNormalize(QuatFromEulerYXZ(rx, ry, rz));
+    Vec3 a = QuatRotate(q, p);
+    Vec3 b = RotateEulerYXZRef(p, rx, ry, rz);
+
+    EXPECT_NEAR(a.x(), b.x(), 1e-5f);
+    EXPECT_NEAR(a.y(), b.y(), 1e-5f);
+    EXPECT_NEAR(a.z(), b.z(), 1e-5f);
+}
+
+TEST(Quat, SlerpEndpoints) {
+    Quat a = QuatFromEulerYXZ(0.0f, 0.0f, 0.0f);
+    Quat b = QuatFromEulerYXZ(0.0f, MathConstants::kPi / 2.0f, 0.0f);
+    a = QuatNormalize(a);
+    b = QuatNormalize(b);
+
+    Quat q0 = QuatSlerp(a, b, 0.0f);
+    Quat q1 = QuatSlerp(a, b, 1.0f);
+
+    EXPECT_NEAR(std::fabs(QuatDot(q0, a)), 1.0f, 1e-4f);
+    EXPECT_NEAR(std::fabs(QuatDot(q1, b)), 1.0f, 1e-4f);
+}
+
+TEST(Quat, SlerpMidpoint) {
+    Quat a = QuatNormalize(QuatFromEulerYXZ(0.0f, 0.0f, 0.0f));
+    Quat b = QuatNormalize(QuatFromEulerYXZ(0.0f, MathConstants::kPi / 2.0f, 0.0f));
+    Quat mid = QuatSlerp(a, b, 0.5f);
+    Quat expect = QuatNormalize(QuatFromEulerYXZ(0.0f, MathConstants::kPi / 4.0f, 0.0f));
+    EXPECT_NEAR(std::fabs(QuatDot(mid, expect)), 1.0f, 1e-4f);
+}
+
+TEST(Quat, SlerpHemisphereFlip) {
+    Quat a{1.0f, 0.0f, 0.0f, 0.0f};
+    Quat b{-1.0f, 0.0f, 0.0f, 0.0f};
+    Quat r = QuatSlerp(a, b, 0.5f);
+    r = QuatNormalize(r);
+    EXPECT_NEAR(std::fabs(r.w), 1.0f, 1e-4f);
+    EXPECT_NEAR(r.x, 0.0f, 1e-4f);
+    EXPECT_NEAR(r.y, 0.0f, 1e-4f);
+    EXPECT_NEAR(r.z, 0.0f, 1e-4f);
+}
+
+TEST(Quat, Two90DegYEquals180DegY) {
+    float hpi = MathConstants::kPi / 2.0f;
+    Quat q90 = QuatNormalize(QuatFromEulerYXZ(0.0f, hpi, 0.0f));
+    Quat q180 = QuatMultiply(q90, q90);
+    q180 = QuatNormalize(q180);
+
+    Vec3 v(1.0f, 0.0f, 0.0f);
+    Vec3 out = QuatRotate(q180, v);
+    EXPECT_NEAR(out.x(), -1.0f, 1e-5f);
+    EXPECT_NEAR(out.y(), 0.0f, 1e-5f);
+    EXPECT_NEAR(out.z(), 0.0f, 1e-5f);
+}
+
+}  // namespace skwr

--- a/skewer/tests/unit/test_quat.cc
+++ b/skewer/tests/unit/test_quat.cc
@@ -8,20 +8,26 @@
 
 namespace {
 
-skwr::Vec3 RotateEulerYXZRef(const skwr::Vec3& p, float rx, float ry, float rz) {
-    float cy = std::cos(ry), sy = std::sin(ry);
-    skwr::Vec3 r1(cy * p.x() + sy * p.z(), p.y(), -sy * p.x() + cy * p.z());
+// Intrinsic YXZ reference: R = Ry * Rx * Rz (matches Three.js "YXZ").
+skwr::Vec3 RotateIntrinsicYXZ(const skwr::Vec3& p, float rx, float ry, float rz) {
     float cx = std::cos(rx), sx = std::sin(rx);
-    skwr::Vec3 r2(r1.x(), cx * r1.y() - sx * r1.z(), sx * r1.y() + cx * r1.z());
+    float cy = std::cos(ry), sy = std::sin(ry);
     float cz = std::cos(rz), sz = std::sin(rz);
-    return skwr::Vec3(cz * r2.x() - sz * r2.y(), sz * r2.x() + cz * r2.y(), r2.z());
+
+    // R = Ry * Rx * Rz, applied to p
+    // Rz first
+    skwr::Vec3 r1(cz * p.x() - sz * p.y(), sz * p.x() + cz * p.y(), p.z());
+    // then Rx
+    skwr::Vec3 r2(r1.x(), cx * r1.y() - sx * r1.z(), sx * r1.y() + cx * r1.z());
+    // then Ry
+    return skwr::Vec3(cy * r2.x() + sy * r2.z(), r2.y(), -sy * r2.x() + cy * r2.z());
 }
 
 }  // namespace
 
 namespace skwr {
 
-TEST(Quat, EulerMatchesLegacyYXZ) {
+TEST(Quat, EulerMatchesIntrinsicYXZ) {
     const Vec3 p(0.3f, -1.2f, 2.7f);
     const float rx = 0.41f;
     const float ry = -0.73f;
@@ -29,11 +35,42 @@ TEST(Quat, EulerMatchesLegacyYXZ) {
 
     Quat q = QuatNormalize(QuatFromEulerYXZ(rx, ry, rz));
     Vec3 a = QuatRotate(q, p);
-    Vec3 b = RotateEulerYXZRef(p, rx, ry, rz);
+    Vec3 b = RotateIntrinsicYXZ(p, rx, ry, rz);
 
     EXPECT_NEAR(a.x(), b.x(), 1e-5f);
     EXPECT_NEAR(a.y(), b.y(), 1e-5f);
     EXPECT_NEAR(a.z(), b.z(), 1e-5f);
+}
+
+TEST(Quat, SingleAxisMatchesBothConventions) {
+    const Vec3 p(1.0f, 2.0f, 3.0f);
+    float ry = MathConstants::kPi / 3.0f;
+
+    Quat q = QuatNormalize(QuatFromEulerYXZ(0.0f, ry, 0.0f));
+    Vec3 a = QuatRotate(q, p);
+    Vec3 b = RotateIntrinsicYXZ(p, 0.0f, ry, 0.0f);
+
+    EXPECT_NEAR(a.x(), b.x(), 1e-5f);
+    EXPECT_NEAR(a.y(), b.y(), 1e-5f);
+    EXPECT_NEAR(a.z(), b.z(), 1e-5f);
+}
+
+TEST(Quat, SculptureGardenArmadillo) {
+    float rx = 29.0f * MathConstants::kPi / 180.0f;
+    float ry = 230.0f * MathConstants::kPi / 180.0f;
+    float rz = 0.0f;
+
+    Quat q = QuatNormalize(QuatFromEulerYXZ(rx, ry, rz));
+    Vec3 up = QuatRotate(q, Vec3(0.0f, 1.0f, 0.0f));
+    Vec3 ref = RotateIntrinsicYXZ(Vec3(0.0f, 1.0f, 0.0f), rx, ry, rz);
+
+    EXPECT_NEAR(up.x(), ref.x(), 1e-5f);
+    EXPECT_NEAR(up.y(), ref.y(), 1e-5f);
+    EXPECT_NEAR(up.z(), ref.z(), 1e-5f);
+
+    // Intrinsic YXZ: the 29° X pitch should tilt in the local frame after 230° Y yaw,
+    // so up.x should be non-zero (unlike extrinsic where up.x == 0 after Y-then-worldX).
+    EXPECT_TRUE(std::fabs(up.x()) > 0.1f);
 }
 
 TEST(Quat, SlerpEndpoints) {

--- a/skewer/tests/unit/test_quat.cc
+++ b/skewer/tests/unit/test_quat.cc
@@ -105,6 +105,16 @@ TEST(Quat, SlerpHemisphereFlip) {
     EXPECT_NEAR(r.z, 0.0f, 1e-4f);
 }
 
+TEST(Quat, SlerpClampsOversizedDot) {
+    Quat a{1.01f, 0.0f, 0.0f, 0.0f};
+    Quat b{1.01f, 0.0f, 0.0f, 0.0f};
+    Quat r = QuatSlerp(a, b, 0.25f);
+    r = QuatNormalize(r);
+    EXPECT_TRUE(std::isfinite(r.w) && std::isfinite(r.x) && std::isfinite(r.y) &&
+                std::isfinite(r.z));
+    EXPECT_NEAR(std::fabs(QuatDot(r, QuatNormalize(a))), 1.0f, 1e-4f);
+}
+
 TEST(Quat, Two90DegYEquals180DegY) {
     float hpi = MathConstants::kPi / 2.0f;
     Quat q90 = QuatNormalize(QuatFromEulerYXZ(0.0f, hpi, 0.0f));

--- a/skewer/tests/unit/test_trs.cc
+++ b/skewer/tests/unit/test_trs.cc
@@ -8,6 +8,31 @@
 
 namespace skwr {
 
+TEST(TRS, IdentityQuaternionNegativeW) {
+    TRS trs{};
+    trs.rotation = Quat{-1.0f, 0.0f, 0.0f, 0.0f};
+    EXPECT_TRUE(TRSIsIdentity(trs));
+}
+
+TEST(TRS, FullCircleEulerIsIdentityTRS) {
+    TRS trs =
+        TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(360.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    EXPECT_TRUE(TRSIsIdentity(trs));
+}
+
+TEST(TRS, ApplyNormalDegenerateScaleUsesRotationOnly) {
+    TRS trs{};
+    trs.rotation = QuatNormalize(QuatFromEulerYXZ(0.0f, MathConstants::kPi / 4.0f, 0.0f));
+    trs.scale = Vec3(0.0f, 1.0f, 1.0f);
+    Vec3 n(0.0f, 1.0f, 0.0f);
+    Vec3 out = TRSApplyNormal(trs, n);
+    Vec3 expect = Normalize(QuatRotate(trs.rotation, n));
+    EXPECT_TRUE(std::isfinite(out.x()) && std::isfinite(out.y()) && std::isfinite(out.z()));
+    EXPECT_NEAR(out.x(), expect.x(), 1e-5f);
+    EXPECT_NEAR(out.y(), expect.y(), 1e-5f);
+    EXPECT_NEAR(out.z(), expect.z(), 1e-5f);
+}
+
 TEST(TRS, IdentityPointAndNormal) {
     TRS id{};
     Vec3 p(3.0f, -2.0f, 1.5f);

--- a/skewer/tests/unit/test_trs.cc
+++ b/skewer/tests/unit/test_trs.cc
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "core/math/constants.h"
+#include "core/math/transform.h"
+#include "core/math/vec3.h"
+
+namespace skwr {
+
+TEST(TRS, IdentityPointAndNormal) {
+    TRS id{};
+    Vec3 p(3.0f, -2.0f, 1.5f);
+    Vec3 n(0.0f, 1.0f, 1.0f);
+    Vec3 pn = Normalize(n);
+
+    Vec3 pt = TRSApplyPoint(id, p);
+    Vec3 nt = TRSApplyNormal(id, pn);
+
+    EXPECT_NEAR(pt.x(), p.x(), 1e-6f);
+    EXPECT_NEAR(pt.y(), p.y(), 1e-6f);
+    EXPECT_NEAR(pt.z(), p.z(), 1e-6f);
+    EXPECT_NEAR(nt.x(), pn.x(), 1e-6f);
+    EXPECT_NEAR(nt.y(), pn.y(), 1e-6f);
+    EXPECT_NEAR(nt.z(), pn.z(), 1e-6f);
+}
+
+TEST(TRS, NormalOrthogonalToTangentUnderNonUniformScale) {
+    Vec3 n(0.0f, 1.0f, 0.0f);
+    Vec3 t(1.0f, 0.0f, 0.0f);
+    TRS trs =
+        TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(25.0f, -40.0f, 15.0f), Vec3(2.0f, 0.5f, 3.0f));
+
+    Vec3 n_w = TRSApplyNormal(trs, n);
+    Vec3 t_lin = Vec3(t.x() * trs.scale.x(), t.y() * trs.scale.y(), t.z() * trs.scale.z());
+    Vec3 t_w = Normalize(QuatRotate(trs.rotation, t_lin));
+
+    EXPECT_NEAR(Dot(n_w, t_w), 0.0f, 1e-5f);
+}
+
+TEST(TRS, ComposeParentRotate90YChildTranslateX) {
+    TRS parent =
+        TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(0.0f, 90.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS child =
+        TRSFromEuler(Vec3(1.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS world = Compose(parent, child);
+
+    Vec3 origin = TRSApplyPoint(world, Vec3(0.0f, 0.0f, 0.0f));
+    EXPECT_NEAR(origin.x(), 0.0f, 1e-5f);
+    EXPECT_NEAR(origin.y(), 0.0f, 1e-5f);
+    EXPECT_NEAR(origin.z(), -1.0f, 1e-5f);
+}
+
+TEST(TRS, ComposeAddsParentTranslation) {
+    TRS parent =
+        TRSFromEuler(Vec3(5.0f, 0.0f, 0.0f), Vec3(0.0f, 90.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS child =
+        TRSFromEuler(Vec3(1.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS world = Compose(parent, child);
+
+    Vec3 origin = TRSApplyPoint(world, Vec3(0.0f, 0.0f, 0.0f));
+    EXPECT_NEAR(origin.x(), 5.0f, 1e-5f);
+    EXPECT_NEAR(origin.y(), 0.0f, 1e-5f);
+    EXPECT_NEAR(origin.z(), -1.0f, 1e-5f);
+}
+
+}  // namespace skwr


### PR DESCRIPTION
This is a pre-cursor to make pose interpolation easier down the line when we add motion blur.

POC showing various objs with different rotations and transformations applied to show that the output is unchanged. Tests were also added.

![out](https://github.com/user-attachments/assets/37dbe7d8-f72b-4823-9345-f34fdc1c8058)

closes #160
