### PR TITLE
[feat] scene graph

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
+
+      - name: Fetch required LFS header
+        run: |
+          git lfs fetch --include="skewer/external/srgb_spec_data.h"
+          git lfs checkout
 
       - name: Restore ccache
         uses: actions/cache@v4

--- a/skewer/CMakeLists.txt
+++ b/skewer/CMakeLists.txt
@@ -61,6 +61,8 @@ endif()
 set(SKEWER_CORE_SOURCES
     src/session/render_session.cc
     src/scene/scene.cc
+    src/scene/interp_curve.cc
+    src/scene/animation.cc
     src/film/deep_segment_pool.cc
     src/film/film.cc
     src/film/image_buffer.cc
@@ -69,6 +71,7 @@ set(SKEWER_CORE_SOURCES
     src/accelerators/bvh.cc
     src/scene/light.cc
     src/io/obj_loader.cc
+    src/io/graph_from_json.cc
     src/io/scene_loader.cc
     src/io/image_io.cc
     src/materials/bsdf.cc
@@ -104,6 +107,9 @@ target_include_directories(skewer-worker
 )
 
 set_source_files_properties(src/io/scene_loader.cc PROPERTIES
+    COMPILE_OPTIONS "-fno-fast-math"
+)
+set_source_files_properties(src/io/graph_from_json.cc PROPERTIES
     COMPILE_OPTIONS "-fno-fast-math"
 )
 

--- a/skewer/src/core/math/constants.h
+++ b/skewer/src/core/math/constants.h
@@ -45,6 +45,11 @@ constexpr float kWeightBlue = 0.0722f;
 constexpr float kWeightBlueSquared = kWeightBlue * kWeightBlue;
 }  // namespace Rec709
 
+namespace Bezier {
+constexpr float kBezierNewtonEps = 1e-6f;
+constexpr int kBezierNewtonMaxIter = 32;
+}  // namespace Bezier
+
 }  // namespace skwr
 
 #endif  // SKWR_CORE_MATH_CONSTANTS_H_

--- a/skewer/src/core/math/transform.h
+++ b/skewer/src/core/math/transform.h
@@ -49,6 +49,11 @@ inline Vec3 TRSApplyNormal(const TRS& trs, const Vec3& n) {
     return Normalize(QuatRotate(trs.rotation, inv_scaled));
 }
 
+inline bool TRSIsUniformScale(const TRS& trs, float eps = 1e-5f) {
+    float sx = trs.scale.x(), sy = trs.scale.y(), sz = trs.scale.z();
+    return std::fabs(sx - sy) <= eps && std::fabs(sy - sz) <= eps;
+}
+
 inline bool TRSIsIdentity(const TRS& trs) {
     if (std::fabs(trs.translation.x()) > Numeric::kNearZeroEpsilon ||
         std::fabs(trs.translation.y()) > Numeric::kNearZeroEpsilon ||

--- a/skewer/src/io/graph_from_json.cc
+++ b/skewer/src/io/graph_from_json.cc
@@ -1,0 +1,119 @@
+#include "io/graph_from_json.h"
+
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+
+#include "core/math/vec3.h"
+#include "scene/interp_curve.h"
+
+using json = nlohmann::json;
+
+namespace skwr {
+
+namespace {
+
+Vec3 ParseVec3(const json& j) {
+    if (!j.is_array() || j.size() != 3) {
+        throw std::runtime_error("Expected array of 3 numbers for Vec3");
+    }
+    return Vec3(j[0].get<float>(), j[1].get<float>(), j[2].get<float>());
+}
+
+void ApplyScaleField(const json& scale_field, Vec3& out_s) {
+    if (scale_field.is_number()) {
+        float s = scale_field.get<float>();
+        out_s = Vec3(s, s, s);
+    } else {
+        out_s = ParseVec3(scale_field);
+    }
+}
+
+void PatchTRSFields(const json& j, Vec3& t, Vec3& rotate_deg, Vec3& s) {
+    if (j.contains("translate")) {
+        t = ParseVec3(j["translate"]);
+    }
+    if (j.contains("rotate")) {
+        rotate_deg = ParseVec3(j["rotate"]);
+    }
+    if (j.contains("scale")) {
+        ApplyScaleField(j["scale"], s);
+    }
+}
+
+std::shared_ptr<const InterpolationCurve> SharedPreset(const BezierCurve& preset) {
+    return std::shared_ptr<const InterpolationCurve>(&preset, [](const InterpolationCurve*) {});
+}
+
+}  // namespace
+
+TRS ParseTRSFields(const json& j) {
+    Vec3 t(0.0f, 0.0f, 0.0f);
+    Vec3 r(0.0f, 0.0f, 0.0f);
+    Vec3 s(1.0f, 1.0f, 1.0f);
+    PatchTRSFields(j, t, r, s);
+    return TRSFromEuler(t, r, s);
+}
+
+std::shared_ptr<const InterpolationCurve> ParseCurveJson(const json& j) {
+    if (j.is_string()) {
+        std::string s = j.get<std::string>();
+        if (s == "linear") {
+            return SharedPreset(BezierCurve::Linear());
+        }
+        if (s == "ease-in") {
+            return SharedPreset(BezierCurve::EaseIn());
+        }
+        if (s == "ease-out") {
+            return SharedPreset(BezierCurve::EaseOut());
+        }
+        if (s == "ease-in-out") {
+            return SharedPreset(BezierCurve::EaseInOut());
+        }
+        throw std::runtime_error("Unknown interpolation curve name: " + s);
+    }
+    if (j.is_object() && j.contains("bezier")) {
+        const auto& a = j.at("bezier");
+        if (!a.is_array() || a.size() != 4) {
+            throw std::runtime_error("'bezier' must be an array of 4 numbers");
+        }
+        return std::make_shared<BezierCurve>(a[0].get<float>(), a[1].get<float>(),
+                                             a[2].get<float>(), a[3].get<float>());
+    }
+    throw std::runtime_error("Curve must be a preset string or {\"bezier\":[...]} object");
+}
+
+AnimatedTransform ParseAnimatedTransformJson(const json& t) {
+    AnimatedTransform anim;
+    if (t.contains("keyframes")) {
+        const auto& kfs = t.at("keyframes");
+        if (!kfs.is_array() || kfs.empty()) {
+            throw std::runtime_error("'keyframes' must be a non-empty array");
+        }
+        Vec3 cur_t(0.0f, 0.0f, 0.0f);
+        Vec3 cur_r(0.0f, 0.0f, 0.0f);
+        Vec3 cur_s(1.0f, 1.0f, 1.0f);
+        for (const auto& kf : kfs) {
+            PatchTRSFields(kf, cur_t, cur_r, cur_s);
+            Keyframe k;
+            k.time = kf.at("time").get<float>();
+            k.transform = TRSFromEuler(cur_t, cur_r, cur_s);
+            if (kf.contains("curve")) {
+                k.curve = ParseCurveJson(kf["curve"]);
+            } else {
+                k.curve = SharedPreset(BezierCurve::Linear());
+            }
+            anim.keyframes.push_back(k);
+        }
+        anim.SortKeyframes();
+        return anim;
+    }
+
+    Keyframe k;
+    k.time = 0.0f;
+    k.transform = ParseTRSFields(t);
+    k.curve = SharedPreset(BezierCurve::Linear());
+    anim.keyframes.push_back(k);
+    return anim;
+}
+
+}  // namespace skwr

--- a/skewer/src/io/graph_from_json.h
+++ b/skewer/src/io/graph_from_json.h
@@ -1,0 +1,24 @@
+#ifndef SKWR_IO_GRAPH_FROM_JSON_H_
+#define SKWR_IO_GRAPH_FROM_JSON_H_
+
+#include <memory>
+#include <nlohmann/json_fwd.hpp>
+
+#include "core/math/transform.h"
+#include "scene/animation.h"
+
+namespace skwr {
+
+class InterpolationCurve;
+
+// Parses translate / rotate (degrees) / scale (scalar or [x,y,z]) with defaults (identity).
+TRS ParseTRSFields(const nlohmann::json& j);
+
+std::shared_ptr<const InterpolationCurve> ParseCurveJson(const nlohmann::json& j);
+
+// Full "transform" object: either { keyframes: [...] } or static TRS fields.
+AnimatedTransform ParseAnimatedTransformJson(const nlohmann::json& j);
+
+}  // namespace skwr
+
+#endif

--- a/skewer/src/io/scene_loader.cc
+++ b/skewer/src/io/scene_loader.cc
@@ -15,6 +15,7 @@
 #include "core/spectral/spectral_curve.h"
 #include "core/spectral/spectral_utils.h"
 #include "geometry/sphere.h"
+#include "io/graph_from_json.h"
 #include "io/obj_loader.h"
 #include "materials/material.h"
 #include "materials/texture.h"
@@ -22,6 +23,7 @@
 #include "media/nano_vdb_medium.h"
 #include "scene/mesh_utils.h"
 #include "scene/scene.h"
+#include "scene/scene_graph.h"
 #include "session/render_options.h"
 
 using json = nlohmann::json;
@@ -206,7 +208,7 @@ static MaterialMap ParseMaterials(const json& j, Scene& scene, const std::string
 }
 
 //------------------------------------------------------------------------------
-// Object Parsing
+// Graph parsing
 //------------------------------------------------------------------------------
 
 static uint16_t LookupMedium(const json& obj, const MediaMap& media_map, const std::string& key) {
@@ -258,101 +260,26 @@ static uint32_t LookupMaterialWithVisibility(const json& obj, const MaterialMap&
     return scene.AddMaterial(cloned);
 }
 
-static void ParseSphere(const json& obj, const MaterialMap& mat_map, const MediaMap& media_map,
-                        Scene& scene, int index) {
-    uint32_t mat_id = LookupMaterialWithVisibility(obj, mat_map, scene, index);
-
-    uint16_t inside = LookupMedium(obj, media_map, "inside_medium");
-    uint16_t outside = LookupMedium(obj, media_map, "outside_medium");
-
-    Vec3 center(0.0f, 0.0f, 0.0f);
-    float radius = 1.0f;
-
-    uint16_t med_index = ExtractMediumIndex(inside);
-    MediumType med_type = ExtractMediumType(inside);
-
-    if (inside != kVacuumMediumId && med_type == MediumType::NanoVDB) {
-        const NanoVDBMedium& medium = scene.nanovdb_media()[med_index];
-        center = medium.Center();
-        radius = medium.BoundingRadius() * 1.05f;  // padding
-    } else {
-        center = ParseVec3(obj.at("center"));
-        radius = obj.at("radius").get<float>();
-    }
-    int32_t light_index = -1;
-    uint16_t priority = 1;
-
-    scene.AddSphere(Sphere{center, radius, mat_id, light_index, inside, outside, priority});
-}
-
-static void ParseQuad(const json& obj, const MaterialMap& mat_map, Scene& scene, int index) {
-    uint32_t mat_id = LookupMaterialWithVisibility(obj, mat_map, scene, index);
-
-    const auto& verts = obj.at("vertices");
-    if (!verts.is_array() || verts.size() != 4) {
-        throw std::runtime_error("Object at index " + std::to_string(index) +
-                                 ": quad 'vertices' must be array of 4 points");
-    }
-
-    Vec3 p0 = ParseVec3(verts[0]);
-    Vec3 p1 = ParseVec3(verts[1]);
-    Vec3 p2 = ParseVec3(verts[2]);
-    Vec3 p3 = ParseVec3(verts[3]);
-
-    scene.AddMesh(CreateQuad(p0, p1, p2, p3, mat_id));
-
-    std::string comment = GetOr<std::string>(obj, "comment", "");
-}
-
-static void ParseObj(const json& obj, const MaterialMap& mat_map, Scene& scene, int index,
-                     const std::string& scene_dir) {
+static void LoadObjMeshes(const json& obj, const MaterialMap& mat_map, Scene& scene, int index,
+                          const std::string& scene_dir) {
     std::string file = obj.at("file").get<std::string>();
     std::string filepath = ResolvePath(file, scene_dir);
 
     bool auto_fit = GetOr(obj, "auto_fit", true);
 
-    // Parse transform
-    Vec3 translate(0.0f, 0.0f, 0.0f);
-    Vec3 rotate_deg(0.0f, 0.0f, 0.0f);
-    Vec3 obj_scale(1.0f, 1.0f, 1.0f);
-
-    if (obj.contains("transform")) {
-        const auto& t = obj["transform"];
-        translate = GetVec3Or(t, "translate", Vec3(0.0f, 0.0f, 0.0f));
-        rotate_deg = GetVec3Or(t, "rotate", Vec3(0.0f, 0.0f, 0.0f));
-
-        // Scale can be a scalar or a [x,y,z] array
-        if (t.contains("scale")) {
-            if (t["scale"].is_number()) {
-                float s = t["scale"].get<float>();
-                obj_scale = Vec3(s, s, s);
-            } else {
-                obj_scale = ParseVec3(t["scale"]);
-            }
-        }
-    }
-
-    // Record mesh count before loading so we can apply transforms to new meshes
     size_t mesh_count_before = scene.MeshCount();
 
-    // Load OBJ — when auto_fit is true, the loader normalizes to 2-unit cube.
-    // We pass Vec3(1,1,1) as scale here because we apply TRS (scale → rotate → translate) after
-    // load.
     if (!LoadOBJ(filepath, scene, Vec3(1.0f, 1.0f, 1.0f), auto_fit)) {
-        throw std::runtime_error("Object at index " + std::to_string(index) +
-                                 ": failed to load OBJ file '" + filepath + "'");
+        throw std::runtime_error("Graph node " + std::to_string(index) + ": failed to load OBJ '" +
+                                 filepath + "'");
     }
 
-    // Override material if specified (also applies object-level visible override)
     if (obj.contains("material") && !obj["material"].is_null()) {
         uint32_t mat_id = LookupMaterialWithVisibility(obj, mat_map, scene, index);
         for (size_t i = mesh_count_before; i < scene.MeshCount(); i++) {
             scene.GetMutableMesh(static_cast<uint32_t>(i)).material_id = mat_id;
         }
     } else if (obj.contains("visible")) {
-        // No material override, but a visibility flag was set.  The OBJ may
-        // have loaded multiple sub-meshes with different materials; clone each
-        // unique material with the requested visibility.
         bool want_visible = obj["visible"].get<bool>();
         std::unordered_map<uint32_t, uint32_t> vis_cache;
         for (size_t i = mesh_count_before; i < scene.MeshCount(); i++) {
@@ -373,45 +300,119 @@ static void ParseObj(const json& obj, const MaterialMap& mat_map, Scene& scene, 
             }
         }
     }
-
-    TRS trs = TRSFromEuler(translate, rotate_deg, obj_scale);
-    if (!TRSIsIdentity(trs)) {
-        for (size_t i = mesh_count_before; i < scene.MeshCount(); i++) {
-            Mesh& mesh = scene.GetMutableMesh(static_cast<uint32_t>(i));
-            for (Vec3& v : mesh.p) {
-                v = TRSApplyPoint(trs, v);
-            }
-            if (!mesh.n.empty()) {
-                for (Vec3& n : mesh.n) {
-                    n = TRSApplyNormal(trs, n);
-                }
-            }
-        }
-    }
 }
 
-static void ParseObjects(const json& j, const MaterialMap& mat_map, const MediaMap& media_map,
-                         Scene& scene, const std::string& scene_dir) {
-    if (!j.contains("objects")) {
-        return;
+static SceneNode ParseGraphNode(const json& j, const MaterialMap& mat_map,
+                                const MediaMap& media_map, Scene& scene,
+                                const std::string& scene_dir, const std::string& path_label) {
+    SceneNode node;
+
+    if (j.contains("name") && j["name"].is_string()) {
+        node.name = j["name"].get<std::string>();
     }
 
-    const auto& objects = j["objects"];
-    for (int i = 0; i < static_cast<int>(objects.size()); i++) {
-        const auto& obj = objects[i];
-        std::string type = obj.at("type").get<std::string>();
+    if (j.contains("transform")) {
+        node.anim_transform = ParseAnimatedTransformJson(j["transform"]);
+    } else {
+        node.anim_transform = ParseAnimatedTransformJson(json::object());
+    }
 
-        if (type == "sphere") {
-            ParseSphere(obj, mat_map, media_map, scene, i);
-        } else if (type == "quad") {
-            ParseQuad(obj, mat_map, scene, i);
-        } else if (type == "obj") {
-            ParseObj(obj, mat_map, scene, i, scene_dir);
-        } else {
-            throw std::runtime_error("Object at index " + std::to_string(i) + ": unknown type '" +
-                                     type + "'");
+    if (j.contains("children")) {
+        if (!j["children"].is_array()) {
+            throw std::runtime_error("Graph node " + path_label + ": 'children' must be an array");
         }
+        node.type = NodeType::Group;
+        int ci = 0;
+        for (const auto& ch : j["children"]) {
+            node.children.push_back(
+                ParseGraphNode(ch, mat_map, media_map, scene, scene_dir,
+                               path_label + ".children[" + std::to_string(ci++) + "]"));
+        }
+        return node;
     }
+
+    std::string typ = j.at("type").get<std::string>();
+
+    if (typ == "sphere") {
+        node.type = NodeType::Sphere;
+        uint32_t mat_id = LookupMaterialWithVisibility(j, mat_map, scene, -1);
+
+        uint16_t inside = LookupMedium(j, media_map, "inside_medium");
+        uint16_t outside = LookupMedium(j, media_map, "outside_medium");
+
+        SphereData sd{};
+        sd.material_id = mat_id;
+        sd.light_index = -1;
+        sd.interior_medium = inside;
+        sd.exterior_medium = outside;
+        sd.priority = 1;
+
+        uint16_t med_index = ExtractMediumIndex(inside);
+        MediumType med_type = ExtractMediumType(inside);
+
+        if (inside != kVacuumMediumId && med_type == MediumType::NanoVDB) {
+            const NanoVDBMedium& medium = scene.nanovdb_media()[med_index];
+            sd.center = medium.Center();
+            sd.radius = medium.BoundingRadius() * 1.05f;
+            sd.center_is_world = true;
+        } else {
+            sd.center = ParseVec3(j.at("center"));
+            sd.radius = j.at("radius").get<float>();
+            sd.center_is_world = false;
+        }
+        node.sphere_data = sd;
+        return node;
+    }
+
+    if (typ == "quad") {
+        node.type = NodeType::Mesh;
+        uint32_t mat_id = LookupMaterialWithVisibility(j, mat_map, scene, -1);
+
+        const auto& verts = j.at("vertices");
+        if (!verts.is_array() || verts.size() != 4) {
+            throw std::runtime_error("Graph node " + path_label +
+                                     ": quad 'vertices' must be array of 4 points");
+        }
+
+        Vec3 p0 = ParseVec3(verts[0]);
+        Vec3 p1 = ParseVec3(verts[1]);
+        Vec3 p2 = ParseVec3(verts[2]);
+        Vec3 p3 = ParseVec3(verts[3]);
+
+        uint32_t mid = scene.AddMesh(CreateQuad(p0, p1, p2, p3, mat_id));
+        node.mesh_ids.push_back(mid);
+        return node;
+    }
+
+    if (typ == "obj") {
+        node.type = NodeType::Mesh;
+        size_t mesh_count_before = scene.MeshCount();
+        LoadObjMeshes(j, mat_map, scene, -1, scene_dir);
+        for (size_t i = mesh_count_before; i < scene.MeshCount(); i++) {
+            node.mesh_ids.push_back(static_cast<uint32_t>(i));
+        }
+        return node;
+    }
+
+    throw std::runtime_error("Graph node " + path_label + ": unknown type '" + typ + "'");
+}
+
+static void ParseGraph(const json& j, const MaterialMap& mat_map, const MediaMap& media_map,
+                       Scene& scene, const std::string& scene_dir, const std::string& filepath) {
+    if (!j.contains("graph")) {
+        throw std::runtime_error("Layer file must use 'graph' format: " + filepath);
+    }
+    const auto& g = j["graph"];
+    if (!g.is_array()) {
+        throw std::runtime_error("'graph' must be an array in: " + filepath);
+    }
+    std::vector<SceneNode> roots;
+    roots.reserve(g.size());
+    for (size_t i = 0; i < g.size(); i++) {
+        roots.push_back(ParseGraphNode(g[i], mat_map, media_map, scene, scene_dir,
+                                       "graph[" + std::to_string(i) + "]"));
+    }
+    scene.MergeGraphRoots(std::move(roots));
 }
 
 //------------------------------------------------------------------------------
@@ -553,7 +554,7 @@ LayerConfig LoadLayerFile(const std::string& filepath, Scene& scene) {
 
     MaterialMap mat_map = ParseMaterials(j, scene, scene_dir, layer_visible);
     MediaMap media_map = ParseMedia(j, scene, scene_dir);
-    ParseObjects(j, mat_map, media_map, scene, scene_dir);
+    ParseGraph(j, mat_map, media_map, scene, scene_dir, filepath);
 
     LayerConfig lcfg{};
     lcfg.visible = layer_visible;
@@ -572,7 +573,7 @@ void LoadContextIntoScene(const std::vector<std::string>& context_paths, Scene& 
         std::string ctx_dir = ExtractDir(path);
         MaterialMap mat_map = ParseMaterials(j, scene, ctx_dir);
         MediaMap media_map = ParseMedia(j, scene, ctx_dir);
-        ParseObjects(j, mat_map, media_map, scene, ctx_dir);
+        ParseGraph(j, mat_map, media_map, scene, ctx_dir, path);
     }
 }
 

--- a/skewer/src/scene/animation.cc
+++ b/skewer/src/scene/animation.cc
@@ -1,0 +1,65 @@
+#include "scene/animation.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "core/math/quat.h"
+#include "scene/interp_curve.h"
+
+namespace skwr {
+
+namespace {
+
+inline Vec3 LerpVec3(const Vec3& a, const Vec3& b, float s) { return a + (b - a) * s; }
+
+inline float EvalCurveOrLinear(const std::shared_ptr<const InterpolationCurve>& curve, float u) {
+    if (curve) return curve->Evaluate(u);
+    return BezierCurve::Linear().Evaluate(u);
+}
+
+}  // namespace
+
+void AnimatedTransform::SortKeyframes() {
+    std::sort(keyframes.begin(), keyframes.end(),
+              [](const Keyframe& a, const Keyframe& b) { return a.time < b.time; });
+}
+
+TRS AnimatedTransform::Evaluate(float t) const {
+    if (keyframes.empty()) {
+        return TRS{};
+    }
+    if (keyframes.size() == 1) {
+        return keyframes[0].transform;
+    }
+
+    const Keyframe& first = keyframes.front();
+    const Keyframe& last = keyframes.back();
+    if (t <= first.time) {
+        return first.transform;
+    }
+    if (t >= last.time) {
+        return last.transform;
+    }
+
+    // keyframes[i].time <= t < keyframes[i+1].time
+    auto it = std::upper_bound(keyframes.begin(), keyframes.end(), t,
+                               [](float time, const Keyframe& k) { return time < k.time; });
+    size_t i = static_cast<size_t>(std::distance(keyframes.begin(), it)) - 1;
+    const Keyframe& k0 = keyframes[i];
+    const Keyframe& k1 = keyframes[i + 1];
+    float dt = k1.time - k0.time;
+    if (dt <= 1e-20f) {
+        return k1.transform;
+    }
+    float local_u = (t - k0.time) / dt;
+    local_u = std::clamp(local_u, 0.0f, 1.0f);
+    float alpha = EvalCurveOrLinear(k0.curve, local_u);
+
+    TRS out{};
+    out.translation = LerpVec3(k0.transform.translation, k1.transform.translation, alpha);
+    out.scale = LerpVec3(k0.transform.scale, k1.transform.scale, alpha);
+    out.rotation = QuatNormalize(QuatSlerp(k0.transform.rotation, k1.transform.rotation, alpha));
+    return out;
+}
+
+}  // namespace skwr

--- a/skewer/src/scene/animation.h
+++ b/skewer/src/scene/animation.h
@@ -1,0 +1,32 @@
+#ifndef SKWR_SCENE_ANIMATION_H_
+#define SKWR_SCENE_ANIMATION_H_
+
+#include <memory>
+#include <vector>
+
+#include "core/math/transform.h"
+
+namespace skwr {
+
+class InterpolationCurve;
+
+struct Keyframe {
+    float time = 0.0f;
+    TRS transform;
+    // Easing from this keyframe toward the next; ignored on last keyframe.
+    std::shared_ptr<const InterpolationCurve> curve;
+};
+
+struct AnimatedTransform {
+    std::vector<Keyframe> keyframes;
+
+    TRS Evaluate(float t) const;
+
+    bool IsStatic() const { return keyframes.size() <= 1; }
+
+    void SortKeyframes();
+};
+
+}  // namespace skwr
+
+#endif

--- a/skewer/src/scene/interp_curve.cc
+++ b/skewer/src/scene/interp_curve.cc
@@ -3,14 +3,11 @@
 #include <algorithm>
 #include <cmath>
 
+#include "core/math/constants.h"
+
 namespace skwr {
 
-namespace {
-
-const float kBezierNewtonEps = 1e-6f;
-const int kBezierNewtonMaxIter = 32;
-
-}  // namespace
+namespace {}  // namespace
 
 BezierCurve::BezierCurve(float p1x, float p1y, float p2x, float p2y)
     : p1x_(p1x), p1y_(p1y), p2x_(p2x), p2y_(p2y) {}
@@ -40,11 +37,11 @@ float BezierCurve::SolveForT(float u) const {
 
     // Initial guess: u ~ t for monotonic timing curves
     float t = u;
-    for (int i = 0; i < kBezierNewtonMaxIter; ++i) {
+    for (int i = 0; i < Bezier::kBezierNewtonMaxIter; ++i) {
         float x = SampleX(t);
         float dx = SampleDX(t);
         float f = x - u;
-        if (std::fabs(f) < kBezierNewtonEps) break;
+        if (std::fabs(f) < Bezier::kBezierNewtonEps) break;
         if (std::fabs(dx) < 1e-8f) break;
         t -= f / dx;
         t = std::clamp(t, 0.0f, 1.0f);

--- a/skewer/src/scene/interp_curve.cc
+++ b/skewer/src/scene/interp_curve.cc
@@ -1,0 +1,81 @@
+#include "scene/interp_curve.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace skwr {
+
+namespace {
+
+const float kBezierNewtonEps = 1e-6f;
+const int kBezierNewtonMaxIter = 32;
+
+}  // namespace
+
+BezierCurve::BezierCurve(float p1x, float p1y, float p2x, float p2y)
+    : p1x_(p1x), p1y_(p1y), p2x_(p2x), p2y_(p2y) {}
+
+float BezierCurve::SampleX(float t) const {
+    float u = 1.0f - t;
+    // x0=0, x3=1
+    return 3.0f * u * u * t * p1x_ + 3.0f * u * t * t * p2x_ + t * t * t;
+}
+
+float BezierCurve::SampleY(float t) const {
+    float u = 1.0f - t;
+    return 3.0f * u * u * t * p1y_ + 3.0f * u * t * t * p2y_ + t * t * t;
+}
+
+float BezierCurve::SampleDX(float t) const {
+    float u = 1.0f - t;
+    // d/dt of x(t): P0.x=0, P3.x=1
+    float term1 = p1x_ * 3.0f * (u * u - 2.0f * u * t);
+    float term2 = p2x_ * 3.0f * (-t * t + 2.0f * u * t);
+    return term1 + term2 + 3.0f * t * t;
+}
+
+float BezierCurve::SolveForT(float u) const {
+    if (u <= 0.0f) return 0.0f;
+    if (u >= 1.0f) return 1.0f;
+
+    // Initial guess: u ~ t for monotonic timing curves
+    float t = u;
+    for (int i = 0; i < kBezierNewtonMaxIter; ++i) {
+        float x = SampleX(t);
+        float dx = SampleDX(t);
+        float f = x - u;
+        if (std::fabs(f) < kBezierNewtonEps) break;
+        if (std::fabs(dx) < 1e-8f) break;
+        t -= f / dx;
+        t = std::clamp(t, 0.0f, 1.0f);
+    }
+    return std::clamp(t, 0.0f, 1.0f);
+}
+
+float BezierCurve::Evaluate(float u) const {
+    u = std::clamp(u, 0.0f, 1.0f);
+    float t = SolveForT(u);
+    return SampleY(t);
+}
+
+const BezierCurve& BezierCurve::Linear() {
+    static const BezierCurve k(0.0f, 0.0f, 1.0f, 1.0f);
+    return k;
+}
+
+const BezierCurve& BezierCurve::EaseIn() {
+    static const BezierCurve k(0.42f, 0.0f, 1.0f, 1.0f);
+    return k;
+}
+
+const BezierCurve& BezierCurve::EaseOut() {
+    static const BezierCurve k(0.0f, 0.0f, 0.58f, 1.0f);
+    return k;
+}
+
+const BezierCurve& BezierCurve::EaseInOut() {
+    static const BezierCurve k(0.42f, 0.0f, 0.58f, 1.0f);
+    return k;
+}
+
+}  // namespace skwr

--- a/skewer/src/scene/interp_curve.h
+++ b/skewer/src/scene/interp_curve.h
@@ -1,0 +1,35 @@
+#ifndef SKWR_SCENE_INTERP_CURVE_H_
+#define SKWR_SCENE_INTERP_CURVE_H_
+
+namespace skwr {
+
+// Normalized segment parameter u in [0,1] -> eased value in [0,1]
+class InterpolationCurve {
+  public:
+    virtual ~InterpolationCurve() = default;
+    virtual float Evaluate(float u) const = 0;
+};
+
+// Cubic Bezier with P0=(0,0), P3=(1,1); P1=(p1x,p1y), P2=(p2x,p2y).
+class BezierCurve : public InterpolationCurve {
+  public:
+    BezierCurve(float p1x, float p1y, float p2x, float p2y);
+    float Evaluate(float u) const override;
+
+    static const BezierCurve& Linear();
+    static const BezierCurve& EaseIn();
+    static const BezierCurve& EaseOut();
+    static const BezierCurve& EaseInOut();
+
+  private:
+    float p1x_, p1y_, p2x_, p2y_;
+
+    float SampleX(float t) const;
+    float SampleY(float t) const;
+    float SampleDX(float t) const;
+    float SolveForT(float u) const;
+};
+
+}  // namespace skwr
+
+#endif

--- a/skewer/src/scene/scene.cc
+++ b/skewer/src/scene/scene.cc
@@ -1,9 +1,12 @@
 #include "scene/scene.h"
 
+#include <cmath>
 #include <cstdint>
+#include <stdexcept>
 
 #include "accelerators/bvh.h"
 #include "core/cpu_config.h"
+#include "core/math/transform.h"
 #include "core/math/vec3.h"
 #include "core/transport/surface_interaction.h"
 #include "geometry/intersect_sphere.h"
@@ -16,7 +19,83 @@
 
 namespace skwr {
 
+void Scene::MergeGraphRoots(std::vector<SceneNode>&& roots) {
+    if (roots.empty()) {
+        return;
+    }
+    if (!graph_root_) {
+        SceneNode synthetic;
+        synthetic.type = NodeType::Group;
+        synthetic.children = std::move(roots);
+        graph_root_ = std::move(synthetic);
+        return;
+    }
+    for (auto& r : roots) {
+        graph_root_->children.push_back(std::move(r));
+    }
+}
+
+void Scene::FlattenGraph(const SceneNode& node, const TRS& parent_world) {
+    TRS local = node.anim_transform.Evaluate(0.0f);
+    TRS world = Compose(parent_world, local);
+
+    switch (node.type) {
+        case NodeType::Group:
+            for (const SceneNode& ch : node.children) {
+                FlattenGraph(ch, world);
+            }
+            break;
+        case NodeType::Mesh:
+            for (uint32_t mesh_id : node.mesh_ids) {
+                if (TRSIsIdentity(world)) {
+                    continue;
+                }
+                Mesh& mesh = GetMutableMesh(mesh_id);
+                for (Vec3& v : mesh.p) {
+                    v = TRSApplyPoint(world, v);
+                }
+                if (!mesh.n.empty()) {
+                    for (Vec3& n : mesh.n) {
+                        n = TRSApplyNormal(world, n);
+                    }
+                }
+            }
+            break;
+        case NodeType::Sphere: {
+            if (!node.sphere_data.has_value()) {
+                throw std::runtime_error("Sphere node missing sphere_data");
+            }
+            const SphereData& sd = *node.sphere_data;
+            if (sd.center_is_world) {
+                if (!TRSIsIdentity(world)) {
+                    throw std::runtime_error(
+                        "Sphere with world-space center (e.g. NanoVDB) requires identity world "
+                        "transform");
+                }
+                AddSphere(Sphere{sd.center, sd.radius, sd.material_id, sd.light_index,
+                                 sd.interior_medium, sd.exterior_medium, sd.priority});
+            } else {
+                if (!TRSIsUniformScale(world)) {
+                    throw std::runtime_error(
+                        "Sphere requires uniform scale; non-uniform world scale is not supported");
+                }
+                float s = world.scale.x();
+                Vec3 c = TRSApplyPoint(world, sd.center);
+                float r = sd.radius * std::fabs(s);
+                AddSphere(Sphere{c, r, sd.material_id, sd.light_index, sd.interior_medium,
+                                 sd.exterior_medium, sd.priority});
+            }
+            break;
+        }
+    }
+}
+
 void Scene::Build() {
+    if (graph_root_) {
+        FlattenGraph(*graph_root_, TRS{});
+        graph_root_.reset();
+    }
+
     triangles_.clear();
     lights_.clear();
 
@@ -89,7 +168,7 @@ void Scene::Build() {
         const Material* mat = (triangles_[i].material_id != kNullMaterialId)
                                   ? &materials_[triangles_[i].material_id]
                                   : nullptr;
-        if (mat->IsEmissive()) {
+        if (mat != nullptr && mat->IsEmissive()) {
             AreaLight light;
             light.type = AreaLight::Triangle;
             light.primitive_index = i;
@@ -98,7 +177,7 @@ void Scene::Build() {
             triangles_[i].light_index = static_cast<int32_t>(lights_.size() - 1);
         }
     }
-    inv_light_count_ = 1.0f / lights_.size();
+    inv_light_count_ = lights_.empty() ? 0.0f : 1.0f / static_cast<float>(lights_.size());
 }
 
 bool Scene::Intersect(const Ray& r, float t_min, float t_max, SurfaceInteraction* si) const {

--- a/skewer/src/scene/scene.h
+++ b/skewer/src/scene/scene.h
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "accelerators/bvh.h"
@@ -15,6 +16,7 @@
 #include "media/mediums.h"
 #include "media/nano_vdb_medium.h"
 #include "scene/light.h"
+#include "scene/scene_graph.h"
 
 namespace skwr {
 
@@ -50,7 +52,11 @@ class Scene {
     const std::vector<NanoVDBMedium>& nanovdb_media() const { return nanovdb_media_; }
     const float& InvLightCount() const { return inv_light_count_; }
 
-    void Build();  // Construct the BVH from the shapes list
+    void Build();  // Flatten scene graph (if any), then construct the BVH from the shapes list
+
+    void MergeGraphRoots(std::vector<SceneNode>&& roots);
+
+    bool HasGraph() const { return graph_root_.has_value(); }
 
     // THE CRITICAL HOT-PATH FUNCTION
     // The Integrator calls this millions of times.
@@ -58,6 +64,9 @@ class Scene {
     bool Intersect(const Ray& r, float t_min, float t_max, SurfaceInteraction* si) const;
 
   private:
+    void FlattenGraph(const SceneNode& node, const TRS& parent_world);
+
+    std::optional<SceneNode> graph_root_;
     std::vector<Sphere> spheres_;
     std::vector<Material> materials_;
     std::vector<ImageTexture> textures_;

--- a/skewer/src/scene/scene_graph.h
+++ b/skewer/src/scene/scene_graph.h
@@ -1,0 +1,40 @@
+#ifndef SKWR_SCENE_SCENE_GRAPH_H_
+#define SKWR_SCENE_SCENE_GRAPH_H_
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "core/math/vec3.h"
+#include "scene/animation.h"
+
+namespace skwr {
+
+enum class NodeType : uint8_t { Group, Mesh, Sphere };
+
+struct SphereData {
+    Vec3 center;
+    float radius = 1.0f;
+    uint32_t material_id = 0;
+    int32_t light_index = -1;
+    uint16_t interior_medium = 0;
+    uint16_t exterior_medium = 0;
+    uint16_t priority = 1;
+    // When true (NanoVDB-derived bounds), center/radius are world-space; parent_world must be
+    // identity.
+    bool center_is_world = false;
+};
+
+struct SceneNode {
+    std::string name;
+    NodeType type = NodeType::Group;
+    AnimatedTransform anim_transform;
+    std::vector<SceneNode> children;
+    std::vector<uint32_t> mesh_ids;
+    std::optional<SphereData> sphere_data;
+};
+
+}  // namespace skwr
+
+#endif

--- a/skewer/tests/CMakeLists.txt
+++ b/skewer/tests/CMakeLists.txt
@@ -11,19 +11,42 @@ set(TEST_SOURCES
     ../src/io/image_io.cc
 )
 
+set(SKEWER_SCENE_TEST_SOURCES
+    ../src/scene/scene.cc
+    ../src/scene/interp_curve.cc
+    ../src/scene/animation.cc
+    ../src/accelerators/bvh.cc
+    ../src/scene/light.cc
+    ../src/io/graph_from_json.cc
+    ../src/io/scene_loader.cc
+    ../src/io/obj_loader.cc
+    ../src/core/spectral/rgb2spec.cc
+    ../src/materials/texture.cc
+    ../src/materials/bsdf.cc
+)
+
+set_source_files_properties(
+    "${CMAKE_CURRENT_SOURCE_DIR}/../src/io/graph_from_json.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../src/io/scene_loader.cc"
+    PROPERTIES COMPILE_OPTIONS "-fno-fast-math"
+)
+
 # Create the test executable
 add_executable(unit_tests
     unit/test_image_io.cc
     unit/test_film_alpha.cc
     unit/test_quat.cc
     unit/test_trs.cc
+    unit/test_interp_curve.cc
+    unit/test_animation.cc
+    unit/test_scene_graph.cc
     ${TEST_SOURCES}
+    ${SKEWER_SCENE_TEST_SOURCES}
 )
 
 # Include directories (same as main app)
 target_include_directories(unit_tests
-    PRIVATE
-    ${PROJECT_SOURCE_DIR}/src
+    PRIVATE ${PROJECT_SOURCE_DIR}/src
     ${PROJECT_SOURCE_DIR}/external
 )
 
@@ -33,6 +56,7 @@ target_link_libraries(unit_tests
     GTest::gtest_main
     nlohmann_json::nlohmann_json
     exrio::exrio
+    nanovdb
 )
 
 # Auto-discover tests

--- a/skewer/tests/unit/test_animation.cc
+++ b/skewer/tests/unit/test_animation.cc
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+
+#include "core/math/quat.h"
+#include "core/math/transform.h"
+#include "scene/animation.h"
+#include "scene/interp_curve.h"
+
+namespace skwr {
+
+namespace {
+
+std::shared_ptr<const InterpolationCurve> SharedLinear() {
+    static BezierCurve k(0, 0, 1, 1);
+    return std::shared_ptr<const InterpolationCurve>(&k, [](const InterpolationCurve*) {});
+}
+
+Keyframe K(float time, const TRS& trs,
+           const std::shared_ptr<const InterpolationCurve>& curve =
+               std::shared_ptr<const InterpolationCurve>()) {
+    Keyframe kf;
+    kf.time = time;
+    kf.transform = trs;
+    kf.curve = curve ? curve : SharedLinear();
+    return kf;
+}
+
+bool QuatNear(const Quat& a, const Quat& b, float eps = 1e-4f) {
+    float d = std::fabs(QuatDot(a, b));
+    return d > 1.0f - eps;
+}
+
+}  // namespace
+
+TEST(Animation, StaticSingleKeyframe) {
+    AnimatedTransform anim;
+    TRS only =
+        TRSFromEuler(Vec3(1.0f, 2.0f, 3.0f), Vec3(10.0f, 20.0f, 30.0f), Vec3(2.0f, 2.0f, 2.0f));
+    anim.keyframes.push_back(K(0.0f, only));
+    for (float t : {-100.0f, 0.0f, 0.5f, 100.0f}) {
+        TRS e = anim.Evaluate(t);
+        EXPECT_NEAR(e.translation.x(), only.translation.x(), 1e-5f);
+        EXPECT_NEAR(e.scale.x(), only.scale.x(), 1e-5f);
+        EXPECT_TRUE(QuatNear(e.rotation, only.rotation));
+    }
+}
+
+TEST(Animation, TwoKeyframesLinearMidpointTranslationAndRotation) {
+    TRS a = TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS b = TRSFromEuler(Vec3(2.0f, 0.0f, 0.0f), Vec3(0.0f, 90.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+
+    AnimatedTransform anim;
+    anim.keyframes.push_back(K(0.0f, a));
+    anim.keyframes.push_back(K(2.0f, b));
+
+    TRS mid = anim.Evaluate(1.0f);
+    EXPECT_NEAR(mid.translation.x(), 1.0f, 1e-5f);
+    Quat expect_half = QuatNormalize(QuatSlerp(a.rotation, b.rotation, 0.5f));
+    EXPECT_TRUE(QuatNear(mid.rotation, expect_half));
+}
+
+TEST(Animation, EasedSegmentUsesCurveNotHalfway) {
+    TRS a = TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS b = TRSFromEuler(Vec3(0.0f, 0.0f, 10.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+
+    AnimatedTransform linear_anim;
+    Keyframe k0;
+    k0.time = 0.0f;
+    k0.transform = a;
+    k0.curve = SharedLinear();
+    Keyframe k1;
+    k1.time = 1.0f;
+    k1.transform = b;
+    k1.curve = SharedLinear();
+    linear_anim.keyframes = {k0, k1};
+
+    AnimatedTransform ease_anim = linear_anim;
+    static BezierCurve kEase = BezierCurve::EaseIn();
+    ease_anim.keyframes[0].curve =
+        std::shared_ptr<const InterpolationCurve>(&kEase, [](const InterpolationCurve*) {});
+
+    float lin_z = linear_anim.Evaluate(0.5f).translation.z();
+    float ease_z = ease_anim.Evaluate(0.5f).translation.z();
+    EXPECT_NEAR(lin_z, 5.0f, 1e-5f);
+    EXPECT_LT(ease_z, lin_z);
+}
+
+TEST(Animation, ClampBelowFirst) {
+    AnimatedTransform anim;
+    TRS a = TRSFromEuler(Vec3(3.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS b = TRSFromEuler(Vec3(5.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    anim.keyframes = {K(1.0f, a), K(3.0f, b)};
+    TRS e = anim.Evaluate(-10.0f);
+    EXPECT_NEAR(e.translation.x(), 3.0f, 1e-5f);
+}
+
+TEST(Animation, ClampAboveLast) {
+    AnimatedTransform anim;
+    TRS a = TRSFromEuler(Vec3(3.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS b = TRSFromEuler(Vec3(5.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    anim.keyframes = {K(1.0f, a), K(3.0f, b)};
+    TRS e = anim.Evaluate(100.0f);
+    EXPECT_NEAR(e.translation.x(), 5.0f, 1e-5f);
+}
+
+TEST(Animation, ThreeKeyframesMiddleSegment) {
+    TRS t0 = TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS t1 = TRSFromEuler(Vec3(10.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    TRS t2 = TRSFromEuler(Vec3(100.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    AnimatedTransform anim;
+    anim.keyframes = {K(0.0f, t0), K(1.0f, t1), K(2.0f, t2)};
+    TRS e = anim.Evaluate(0.5f);
+    EXPECT_NEAR(e.translation.x(), 5.0f, 1e-5f);
+    EXPECT_GT(e.translation.x(), 0.5f);
+    EXPECT_LT(e.translation.x(), 50.0f);
+}
+
+TEST(Animation, SortKeyframes) {
+    AnimatedTransform anim;
+    anim.keyframes = {K(2.0f, TRSFromEuler(Vec3(2.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f),
+                                           Vec3(1.0f, 1.0f, 1.0f))),
+                      K(0.0f, TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f),
+                                           Vec3(1.0f, 1.0f, 1.0f)))};
+    anim.SortKeyframes();
+    EXPECT_FLOAT_EQ(anim.keyframes[0].time, 0.0f);
+    EXPECT_FLOAT_EQ(anim.keyframes[1].time, 2.0f);
+}
+
+TEST(Animation, IsStatic) {
+    AnimatedTransform a;
+    EXPECT_TRUE(a.keyframes.empty() || a.IsStatic());
+    a.keyframes.push_back(K(0.0f, TRS{}));
+    EXPECT_TRUE(a.IsStatic());
+    a.keyframes.push_back(K(1.0f, TRS{}));
+    EXPECT_FALSE(a.IsStatic());
+}
+
+}  // namespace skwr

--- a/skewer/tests/unit/test_interp_curve.cc
+++ b/skewer/tests/unit/test_interp_curve.cc
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "scene/interp_curve.h"
+
+namespace skwr {
+
+TEST(InterpCurve, LinearEndpoints) {
+    const auto& L = BezierCurve::Linear();
+    EXPECT_NEAR(L.Evaluate(0.0f), 0.0f, 1e-5f);
+    EXPECT_NEAR(L.Evaluate(1.0f), 1.0f, 1e-5f);
+}
+
+TEST(InterpCurve, PresetsEndpoints) {
+    const std::vector<const BezierCurve*> curves = {&BezierCurve::Linear(), &BezierCurve::EaseIn(),
+                                                    &BezierCurve::EaseOut(),
+                                                    &BezierCurve::EaseInOut()};
+    for (const BezierCurve* c : curves) {
+        EXPECT_NEAR(c->Evaluate(0.0f), 0.0f, 1e-5f);
+        EXPECT_NEAR(c->Evaluate(1.0f), 1.0f, 1e-5f);
+    }
+}
+
+TEST(InterpCurve, LinearMidpoint) {
+    EXPECT_NEAR(BezierCurve::Linear().Evaluate(0.5f), 0.5f, 1e-5f);
+}
+
+TEST(InterpCurve, EaseInSlowerThanLinearAtStart) {
+    float lin = BezierCurve::Linear().Evaluate(0.1f);
+    float ein = BezierCurve::EaseIn().Evaluate(0.1f);
+    EXPECT_LT(ein, lin);
+}
+
+TEST(InterpCurve, EaseOutFasterThanLinearAtStart) {
+    float lin = BezierCurve::Linear().Evaluate(0.1f);
+    float eout = BezierCurve::EaseOut().Evaluate(0.1f);
+    EXPECT_GT(eout, lin);
+}
+
+TEST(InterpCurve, EaseInOutBracketed) {
+    float u = 0.25f;
+    float lin = BezierCurve::Linear().Evaluate(u);
+    float eio = BezierCurve::EaseInOut().Evaluate(u);
+    EXPECT_GT(eio, BezierCurve::EaseIn().Evaluate(u));
+    EXPECT_LT(eio, BezierCurve::EaseOut().Evaluate(u));
+    EXPECT_LT(std::fabs(eio - lin), 0.15f);
+}
+
+TEST(InterpCurve, CustomBezierDiagonalMatchesLinear) {
+    // P1=(0,0) P2=(1,1) gives x(t)=t, y(t)=t
+    BezierCurve diag(0.0f, 0.0f, 1.0f, 1.0f);
+    for (float u : {0.0f, 0.1f, 0.33f, 0.9f, 1.0f}) {
+        EXPECT_NEAR(diag.Evaluate(u), BezierCurve::Linear().Evaluate(u), 1e-4f);
+    }
+}
+
+TEST(InterpCurve, CustomBezierAsymmetric) {
+    BezierCurve c(0.2f, 0.5f, 0.8f, 0.5f);
+    float y = c.Evaluate(0.5f);
+    EXPECT_TRUE(std::isfinite(y));
+    EXPECT_GE(y, 0.0f);
+    EXPECT_LE(y, 1.0f);
+}
+
+TEST(InterpCurve, NewtonSamplesStayFiniteAndIn01) {
+    const std::vector<const BezierCurve*> curves = {&BezierCurve::EaseIn(), &BezierCurve::EaseOut(),
+                                                    &BezierCurve::EaseInOut()};
+    for (const BezierCurve* c : curves) {
+        for (float u : {0.01f, 0.05f, 0.11f, 0.37f, 0.5f, 0.63f, 0.89f, 0.99f}) {
+            float y = c->Evaluate(u);
+            EXPECT_TRUE(std::isfinite(y)) << "u=" << u;
+            EXPECT_GE(y, -1e-4f);
+            EXPECT_LE(y, 1.0f + 1e-4f);
+        }
+    }
+}
+
+}  // namespace skwr

--- a/skewer/tests/unit/test_scene_graph.cc
+++ b/skewer/tests/unit/test_scene_graph.cc
@@ -1,0 +1,256 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+
+#include "core/cpu_config.h"
+#include "core/math/quat.h"
+#include "core/math/transform.h"
+#include "core/math/vec3.h"
+#include "core/spectral/spectral_utils.h"
+#include "geometry/mesh.h"
+#include "io/graph_from_json.h"
+#include "io/scene_loader.h"
+#include "materials/material.h"
+#include "scene/animation.h"
+#include "scene/interp_curve.h"
+#include "scene/scene.h"
+#include "scene/scene_graph.h"
+
+namespace skwr {
+namespace {
+
+struct SpectralInit {
+    SpectralInit() { InitSpectralModel(); }
+} g_init_spectral;
+
+}  // namespace
+
+using json = nlohmann::json;
+
+TEST(GraphJson, ParseTRSDefaults) {
+    json j = json::object();
+    TRS t = ParseTRSFields(j);
+    EXPECT_TRUE(TRSIsIdentity(t));
+}
+
+TEST(GraphJson, ParseTRSScalarScale) {
+    json j = {{"translate", {1.0f, 2.0f, 3.0f}}, {"rotate", {0.0f, 90.0f, 0.0f}}, {"scale", 2.0f}};
+    TRS t = ParseTRSFields(j);
+    TRS ref = TRSFromEuler(Vec3(1.0f, 2.0f, 3.0f), Vec3(0.0f, 90.0f, 0.0f), Vec3(2.0f, 2.0f, 2.0f));
+    EXPECT_NEAR(t.translation.x(), ref.translation.x(), 1e-5f);
+    EXPECT_NEAR(t.scale.x(), ref.scale.x(), 1e-5f);
+    EXPECT_NEAR(QuatDot(t.rotation, ref.rotation), 1.0f, 1e-4f);
+}
+
+TEST(GraphJson, ParseCurvePresets) {
+    auto lin = ParseCurveJson(json("linear"));
+    EXPECT_NEAR(lin->Evaluate(0.3f), BezierCurve::Linear().Evaluate(0.3f), 1e-5f);
+    auto ein = ParseCurveJson(json("ease-in"));
+    EXPECT_LT(ein->Evaluate(0.1f), BezierCurve::Linear().Evaluate(0.1f));
+}
+
+TEST(GraphJson, ParseCurveBezierObject) {
+    json j = {{"bezier", {0.2f, 0.5f, 0.8f, 0.6f}}};
+    auto c = ParseCurveJson(j);
+    EXPECT_TRUE(std::isfinite(c->Evaluate(0.4f)));
+}
+
+TEST(GraphJson, ParseCurveInvalidThrows) {
+    EXPECT_THROW(ParseCurveJson(json(42)), std::runtime_error);
+}
+
+TEST(GraphJson, ParseAnimatedTransformStatic) {
+    json j = {{"translate", {0.0f, 1.0f, 0.0f}}, {"scale", 2.0f}};
+    AnimatedTransform a = ParseAnimatedTransformJson(j);
+    ASSERT_EQ(a.keyframes.size(), 1u);
+    EXPECT_NEAR(a.keyframes[0].transform.translation.y(), 1.0f, 1e-5f);
+    EXPECT_NEAR(a.keyframes[0].transform.scale.x(), 2.0f, 1e-5f);
+}
+
+TEST(GraphJson, ParseAnimatedTransformKeyframes) {
+    json j;
+    j["keyframes"] =
+        json::array({{{"time", 0.0f}, {"translate", {0.0f, 0.0f, 0.0f}}},
+                     {{"time", 1.0f}, {"translate", {1.0f, 0.0f, 0.0f}}, {"curve", "linear"}}});
+    AnimatedTransform a = ParseAnimatedTransformJson(j);
+    ASSERT_EQ(a.keyframes.size(), 2u);
+    TRS mid = a.Evaluate(0.5f);
+    EXPECT_NEAR(mid.translation.x(), 0.5f, 1e-5f);
+}
+
+TEST(SceneGraph, LoadLayerQuadFromFile) {
+    std::filesystem::path p =
+        std::filesystem::temp_directory_path() / "skewer_ut_scene_graph_layer.json";
+    {
+        std::ofstream out(p);
+        out << R"({
+  "materials": {
+    "mat": { "type": "lambertian", "albedo": [0.8, 0.8, 0.8] }
+  },
+  "graph": [
+    {
+      "type": "quad",
+      "material": "mat",
+      "vertices": [[0,0,0],[1,0,0],[1,1,0],[0,1,0]]
+    }
+  ]
+})";
+    }
+    Scene scene;
+    LoadLayerFile(p.string(), scene);
+    EXPECT_EQ(scene.MeshCount(), 1u);
+    scene.Build();
+    EXPECT_FALSE(scene.Triangles().empty());
+    std::filesystem::remove(p);
+}
+
+TEST(SceneGraph, NestedTranslateFlatten) {
+    Material mat{};
+    mat.type = MaterialType::Lambertian;
+    mat.albedo = {{0.8f, 0.8f, 0.8f}, 1.0f};
+
+    Scene scene;
+    uint32_t mid = scene.AddMaterial(mat);
+
+    Mesh mesh;
+    mesh.material_id = mid;
+    mesh.p = {Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 0.0f, 0.0f), Vec3(0.0f, 1.0f, 0.0f)};
+    mesh.indices = {0, 1, 2};
+    uint32_t mesh_id = scene.AddMesh(std::move(mesh));
+
+    SceneNode leaf;
+    leaf.type = NodeType::Mesh;
+    leaf.mesh_ids.push_back(mesh_id);
+    leaf.anim_transform = ParseAnimatedTransformJson(json::object());
+
+    SceneNode parent;
+    parent.type = NodeType::Group;
+    Keyframe k;
+    k.time = 0.0f;
+    k.transform =
+        TRSFromEuler(Vec3(5.0f, 3.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    static BezierCurve kLin(0, 0, 1, 1);
+    k.curve = std::shared_ptr<const InterpolationCurve>(&kLin, [](const InterpolationCurve*) {});
+    parent.anim_transform.keyframes.push_back(k);
+    parent.children.push_back(std::move(leaf));
+
+    scene.MergeGraphRoots({std::move(parent)});
+    scene.Build();
+
+    ASSERT_FALSE(scene.Triangles().empty());
+    const Triangle& tri = scene.Triangles()[0];
+    EXPECT_NEAR(tri.p0.x(), 5.0f, 1e-4f);
+    EXPECT_NEAR(tri.p0.y(), 3.0f, 1e-4f);
+}
+
+TEST(SceneGraph, SphereUniformScaleWorld) {
+    Material mat{};
+    mat.type = MaterialType::Lambertian;
+    mat.albedo = {{0.8f, 0.8f, 0.8f}, 1.0f};
+    Scene scene;
+    scene.AddMaterial(mat);
+
+    SceneNode sn;
+    sn.type = NodeType::Sphere;
+    SphereData sd{};
+    sd.center = Vec3(0.0f, 0.0f, 0.0f);
+    sd.radius = 1.0f;
+    sd.material_id = 0;
+    sd.interior_medium = kVacuumMediumId;
+    sd.exterior_medium = kVacuumMediumId;
+    sn.sphere_data = sd;
+
+    SceneNode parent;
+    parent.type = NodeType::Group;
+    Keyframe k;
+    k.time = 0.0f;
+    k.transform =
+        TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(2.0f, 2.0f, 2.0f));
+    static BezierCurve kLin(0, 0, 1, 1);
+    k.curve = std::shared_ptr<const InterpolationCurve>(&kLin, [](const InterpolationCurve*) {});
+    parent.anim_transform.keyframes.push_back(k);
+    parent.children.push_back(std::move(sn));
+
+    scene.MergeGraphRoots({std::move(parent)});
+    scene.Build();
+
+    ASSERT_EQ(scene.Spheres().size(), 1u);
+    EXPECT_NEAR(scene.Spheres()[0].radius, 2.0f, 1e-4f);
+}
+
+TEST(SceneGraph, SphereNonUniformScaleThrows) {
+    Material mat{};
+    mat.type = MaterialType::Lambertian;
+    mat.albedo = {{0.8f, 0.8f, 0.8f}, 1.0f};
+    Scene scene;
+    scene.AddMaterial(mat);
+
+    SceneNode sn;
+    sn.type = NodeType::Sphere;
+    SphereData sd{};
+    sd.center = Vec3(0.0f, 0.0f, 0.0f);
+    sd.radius = 1.0f;
+    sd.material_id = 0;
+    sd.interior_medium = kVacuumMediumId;
+    sd.exterior_medium = kVacuumMediumId;
+    sn.sphere_data = sd;
+
+    SceneNode parent;
+    parent.type = NodeType::Group;
+    Keyframe k;
+    k.time = 0.0f;
+    k.transform =
+        TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(2.0f, 1.0f, 1.0f));
+    static BezierCurve kLin(0, 0, 1, 1);
+    k.curve = std::shared_ptr<const InterpolationCurve>(&kLin, [](const InterpolationCurve*) {});
+    parent.anim_transform.keyframes.push_back(k);
+    parent.children.push_back(std::move(sn));
+
+    scene.MergeGraphRoots({std::move(parent)});
+    EXPECT_THROW(scene.Build(), std::runtime_error);
+}
+
+TEST(SceneGraph, BuildTwiceDoesNotDoubleTransform) {
+    Material mat{};
+    mat.type = MaterialType::Lambertian;
+    mat.albedo = {{0.8f, 0.8f, 0.8f}, 1.0f};
+    Scene scene;
+    scene.AddMaterial(mat);
+
+    Mesh mesh;
+    mesh.material_id = 0;
+    mesh.p = {Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 0.0f, 0.0f), Vec3(0.0f, 1.0f, 0.0f)};
+    mesh.indices = {0, 1, 2};
+    uint32_t mesh_id = scene.AddMesh(std::move(mesh));
+
+    SceneNode leaf;
+    leaf.type = NodeType::Mesh;
+    leaf.mesh_ids.push_back(mesh_id);
+    leaf.anim_transform = ParseAnimatedTransformJson(json::object());
+
+    SceneNode parent;
+    parent.type = NodeType::Group;
+    Keyframe k;
+    k.time = 0.0f;
+    k.transform =
+        TRSFromEuler(Vec3(1.0f, 0.0f, 0.0f), Vec3(0.0f, 0.0f, 0.0f), Vec3(1.0f, 1.0f, 1.0f));
+    static BezierCurve kLin(0, 0, 1, 1);
+    k.curve = std::shared_ptr<const InterpolationCurve>(&kLin, [](const InterpolationCurve*) {});
+    parent.anim_transform.keyframes.push_back(k);
+    parent.children.push_back(std::move(leaf));
+
+    scene.MergeGraphRoots({std::move(parent)});
+    scene.Build();
+    float x1 = scene.Triangles()[0].p0.x();
+    scene.Build();
+    float x2 = scene.Triangles()[0].p0.x();
+    EXPECT_NEAR(x1, x2, 1e-5f);
+    EXPECT_NEAR(x1, 1.0f, 1e-4f);
+}
+
+}  // namespace skwr


### PR DESCRIPTION
This pull request updates the scene format to support a graph format and keyframes for positions. Here's an example of the new format for the cornell box with falling spheres:

```json
{
  "render": {
    ...
  },
  "materials": {
    ...
  },
  "graph": [
    {
      "type": "quad",
      "material": "white",
      "vertices": [
        ...
      ],
      "comment": "floor"
    },
    {
      "type": "quad",
      "material": "white",
      "vertices": [
        ...
      ],
      "comment": "ceiling"
    },
    {
      "type": "quad",
      "material": "white",
      "vertices": [
        ...
      ],
      "comment": "back wall"
    },
    {
      "type": "quad",
      "material": "red",
      "vertices": [
        ...
      ],
      "comment": "left wall"
    },
    {
      "type": "quad",
      "material": "green",
      "vertices": [
        ...
      ],
      "comment": "right wall"
    },
    {
      "type": "quad",
      "material": "light",
      "vertices": [
        ...
      ],
      "comment": "ceiling light"
    },
    {
      "name": "falling_mirror_sphere",
      "transform": {
        "keyframes": [
          {
            "time": 0.0,
            "translate": [
              0,
              2.4,
              0
            ]
          },
          {
            "time": 1.0,
            "translate": [
              0,
              0,
              0
            ],
            "curve": "ease-in"
          }
        ]
      },
      "children": [
        {
          "type": "sphere",
          "material": "mirror",
          "center": [
            -2.5,
            -3.5,
            -12.0
          ],
          "radius": 1.5
        }
      ]
    },
    {
      "name": "falling_glass_sphere",
      "transform": {
        "keyframes": [
          {
            "time": 0.0,
            "translate": [
              0,
              1.9,
              0
            ]
          },
          {
            "time": 1.0,
            "translate": [
              0,
              0,
              0
            ],
            "curve": "ease-in"
          }
        ]
      },
      "children": [
        {
          "type": "sphere",
          "material": "glass",
          "center": [
            2.5,
            -3.5,
            -8.0
          ],
          "radius": 1.5
        }
      ]
    },
    {
      "type": "sphere",
      "material": "glass",
      "center": [
        0.0,
        -3.5,
        -10.0
      ],
      "radius": 1.5
    }
  ]
}
```

Note: Merge #159 first.
Closes #161