### PR TITLE
[feat] motion blur with scene graph

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
+
+      - name: Fetch required LFS header
+        run: |
+          git lfs fetch --include="skewer/external/srgb_spec_data.h"
+          git lfs checkout
 
       - name: Restore ccache
         uses: actions/cache@v4

--- a/skewer/CMakeLists.txt
+++ b/skewer/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SKEWER_CORE_SOURCES
     src/integrators/path_trace.cc
     src/integrators/normals.cc
     src/accelerators/bvh.cc
+    src/accelerators/tlas.cc
     src/scene/light.cc
     src/io/obj_loader.cc
     src/io/graph_from_json.cc

--- a/skewer/src/accelerators/blas.h
+++ b/skewer/src/accelerators/blas.h
@@ -9,6 +9,8 @@
 
 namespace skwr {
 
+// Bottom-Level Acceleration Structure: a BVH over a single mesh's triangles in local space.
+// Multiple Instances can reference the same BLAS with different transform chains.
 struct BLAS {
     BVH bvh;
     std::vector<Triangle> triangles;

--- a/skewer/src/accelerators/blas.h
+++ b/skewer/src/accelerators/blas.h
@@ -1,0 +1,20 @@
+#ifndef SKWR_ACCELERATORS_BLAS_H_
+#define SKWR_ACCELERATORS_BLAS_H_
+
+#include <vector>
+
+#include "accelerators/bvh.h"
+#include "geometry/boundbox.h"
+#include "geometry/triangle.h"
+
+namespace skwr {
+
+struct BLAS {
+    BVH bvh;
+    std::vector<Triangle> triangles;
+    BoundBox local_bounds;
+};
+
+}  // namespace skwr
+
+#endif

--- a/skewer/src/accelerators/bvh.cc
+++ b/skewer/src/accelerators/bvh.cc
@@ -210,7 +210,7 @@ void BVH::Subdivide(uint32_t node_idx, uint32_t first_tri, uint32_t tri_count,
 }
 
 bool BVH::Intersect(const Ray& r, float t_min, float t_max, SurfaceInteraction* si,
-                    const std::vector<Triangle>& triangles) const {
+                    const std::vector<Triangle>& triangles, uint32_t* out_local_tri_index) const {
     if (IsEmpty()) return false;
 
     bool hit_anything = false;
@@ -234,6 +234,9 @@ bool BVH::Intersect(const Ray& r, float t_min, float t_max, SurfaceInteraction* 
                     if (IntersectTriangle(r, tri, t_min, closest_t, si)) {
                         hit_anything = true;
                         closest_t = si->t;
+                        if (out_local_tri_index) {
+                            *out_local_tri_index = node.left_first + i;
+                        }
                     }
                 }
             } else {

--- a/skewer/src/accelerators/bvh.h
+++ b/skewer/src/accelerators/bvh.h
@@ -44,7 +44,8 @@ class BVH {
 
     bool IsEmpty() const { return nodes_.empty(); }
     bool Intersect(const Ray& r, float t_min, float t_max, SurfaceInteraction* si,
-                   const std::vector<Triangle>& triangles) const;
+                   const std::vector<Triangle>& triangles,
+                   uint32_t* out_local_tri_index = nullptr) const;
 
   private:
     std::vector<BVHNode> nodes_;

--- a/skewer/src/accelerators/instance.h
+++ b/skewer/src/accelerators/instance.h
@@ -1,0 +1,25 @@
+#ifndef SKWR_ACCELERATORS_INSTANCE_H_
+#define SKWR_ACCELERATORS_INSTANCE_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "geometry/boundbox.h"
+#include "scene/animation.h"
+
+namespace skwr {
+
+struct Instance {
+    uint32_t blas_id = 0;
+    std::vector<AnimatedTransform> transform_chain;
+    bool is_static = true;
+    TRS static_world_from_local{};
+    BoundBox world_bounds;
+    uint32_t first_light_index = 0;
+    uint32_t light_count = 0;
+    std::vector<int32_t> tri_light_indices;
+};
+
+}  // namespace skwr
+
+#endif

--- a/skewer/src/accelerators/instance.h
+++ b/skewer/src/accelerators/instance.h
@@ -9,6 +9,9 @@
 
 namespace skwr {
 
+// A scene instance: a BLAS reference plus the animated transform chain that places it in the world.
+// Static instances cache a baked world-from-local TRS; animated ones evaluate the chain at
+// ray.time() during intersection.
 struct Instance {
     uint32_t blas_id = 0;
     std::vector<AnimatedTransform> transform_chain;

--- a/skewer/src/accelerators/tlas.cc
+++ b/skewer/src/accelerators/tlas.cc
@@ -13,6 +13,8 @@ namespace skwr {
 
 namespace {
 
+// Converts local-space intersection data back to world space using the same TRS that transformed
+// the ray into local space, keeping normals and tangents consistent with the world-space geometry.
 static void TransformHitToWorld(const TRS& world_from_local, const Ray& world_ray,
                                 SurfaceInteraction* si) {
     si->point = TRSApplyPoint(world_from_local, si->point);
@@ -29,6 +31,8 @@ static constexpr int kSAHBins = 16;
 static constexpr float kCostTraverse = 1.0f;
 static constexpr float kCostIntersect = 4.0f;
 
+// Build reorders instances for cache-friendly traversal (same assumption as BLAS triangle reorder).
+// The caller must keep instances in sync with the TLAS used for intersection.
 void TLAS::Build(std::vector<Instance>& instances) {
     if (instances.empty()) {
         nodes_.clear();
@@ -41,6 +45,7 @@ void TLAS::Build(std::vector<Instance>& instances) {
     std::vector<BVHPrimitiveInfo> primitive_info(instances.size());
     for (size_t i = 0; i < instances.size(); ++i) {
         primitive_info[i].original_index = (uint32_t)i;
+        // world_bounds is motion-expanded over the shutter interval (computed during scene build).
         primitive_info[i].bounds = instances[i].world_bounds;
         primitive_info[i].bounds.PadToMinimums();
         primitive_info[i].centroid = instances[i].world_bounds.Centroid();
@@ -52,6 +57,8 @@ void TLAS::Build(std::vector<Instance>& instances) {
 
     Subdivide(0, 0, (uint32_t)instances.size(), primitive_info, instances);
 
+    // Instances are reordered to match BVH traversal order (same assumption as BLAS triangle
+    // reorder).
     std::vector<Instance> ordered;
     ordered.reserve(instances.size());
     for (const auto& info : primitive_info) {
@@ -60,6 +67,8 @@ void TLAS::Build(std::vector<Instance>& instances) {
     instances = std::move(ordered);
 }
 
+// SAH binning uses instance centroids in world space; degenerate or poorly fitting bounds may
+// produce unbalanced splits.
 void TLAS::Subdivide(uint32_t node_idx, uint32_t first_inst, uint32_t inst_count,
                      std::vector<BVHPrimitiveInfo>& primitive_info,
                      std::vector<Instance>& instances) {
@@ -180,6 +189,7 @@ void TLAS::Subdivide(uint32_t node_idx, uint32_t first_inst, uint32_t inst_count
               instances);
 }
 
+// Ray time drives animation sampling; instances and blases must correspond to TLAS build order.
 bool TLAS::Intersect(const Ray& ray, float t_min, float t_max, SurfaceInteraction* si,
                      const std::vector<BLAS>& blases,
                      const std::vector<Instance>& instances) const {
@@ -203,6 +213,8 @@ bool TLAS::Intersect(const Ray& ray, float t_min, float t_max, SurfaceInteractio
             if (node.tri_count > 0) {
                 for (uint32_t i = 0; i < node.tri_count; ++i) {
                     const Instance& inst = instances[node.left_first + i];
+                    // Evaluate instance transform at ray shutter time; static instances use
+                    // pre-baked transform to avoid redundant chain evaluation.
                     TRS world_from_local =
                         inst.is_static ? inst.static_world_from_local
                                        : EvaluateTransformChain(inst.transform_chain, ray.time());
@@ -218,6 +230,7 @@ bool TLAS::Intersect(const Ray& ray, float t_min, float t_max, SurfaceInteractio
                         hit_anything = true;
                         closest_t = si->t;
                         TransformHitToWorld(world_from_local, ray, si);
+                        // tri_light_indices are in BLAS triangle order (post-BVH reorder).
                         if (tri_idx < inst.tri_light_indices.size()) {
                             si->light_index = inst.tri_light_indices[tri_idx];
                         } else {

--- a/skewer/src/accelerators/tlas.cc
+++ b/skewer/src/accelerators/tlas.cc
@@ -1,0 +1,243 @@
+#include "accelerators/tlas.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "core/math/transform.h"
+#include "geometry/boundbox.h"
+#include "geometry/intersect_triangle.h"
+
+namespace skwr {
+
+namespace {
+
+static void TransformHitToWorld(const TRS& world_from_local, const Ray& world_ray,
+                                SurfaceInteraction* si) {
+    si->point = TRSApplyPoint(world_from_local, si->point);
+    si->n_geom = TRSApplyNormal(world_from_local, si->n_geom);
+    si->n_shading = TRSApplyNormal(world_from_local, si->n_shading);
+    si->dpdu = TRSApplyVector(world_from_local, si->dpdu);
+    si->dpdv = TRSApplyVector(world_from_local, si->dpdv);
+    si->wo = -world_ray.direction();
+}
+
+}  // namespace
+
+static constexpr int kSAHBins = 16;
+static constexpr float kCostTraverse = 1.0f;
+static constexpr float kCostIntersect = 4.0f;
+
+void TLAS::Build(std::vector<Instance>& instances) {
+    if (instances.empty()) {
+        nodes_.clear();
+        return;
+    }
+
+    nodes_.clear();
+    nodes_.reserve(instances.size() * 2);
+
+    std::vector<BVHPrimitiveInfo> primitive_info(instances.size());
+    for (size_t i = 0; i < instances.size(); ++i) {
+        primitive_info[i].original_index = (uint32_t)i;
+        primitive_info[i].bounds = instances[i].world_bounds;
+        primitive_info[i].bounds.PadToMinimums();
+        primitive_info[i].centroid = instances[i].world_bounds.Centroid();
+    }
+
+    BVHNode& root = nodes_.emplace_back();
+    root.left_first = 0;
+    root.tri_count = (uint32_t)instances.size();
+
+    Subdivide(0, 0, (uint32_t)instances.size(), primitive_info, instances);
+
+    std::vector<Instance> ordered;
+    ordered.reserve(instances.size());
+    for (const auto& info : primitive_info) {
+        ordered.push_back(std::move(instances[info.original_index]));
+    }
+    instances = std::move(ordered);
+}
+
+void TLAS::Subdivide(uint32_t node_idx, uint32_t first_inst, uint32_t inst_count,
+                     std::vector<BVHPrimitiveInfo>& primitive_info,
+                     std::vector<Instance>& instances) {
+    BVHNode& node = nodes_[node_idx];
+
+    node.bounds = BoundBox();
+    for (uint32_t i = 0; i < inst_count; ++i) {
+        node.bounds.Expand(primitive_info[first_inst + i].bounds);
+    }
+
+    if (inst_count == 1) {
+        node.left_first = first_inst;
+        node.tri_count = inst_count;
+        return;
+    }
+
+    struct Bin {
+        BoundBox bounds;
+        int count = 0;
+    };
+
+    const float leaf_cost = (float)inst_count * kCostIntersect;
+    const float parent_area = node.bounds.HalfArea();
+
+    float best_cost = std::numeric_limits<float>::max();
+    int best_axis = -1;
+    float best_split = 0.0f;
+
+    for (int axis = 0; axis < 3; ++axis) {
+        float c_min = std::numeric_limits<float>::max();
+        float c_max = std::numeric_limits<float>::lowest();
+        for (uint32_t i = 0; i < inst_count; ++i) {
+            float c = primitive_info[first_inst + i].centroid[axis];
+            c_min = std::fmin(c_min, c);
+            c_max = std::fmax(c_max, c);
+        }
+        if (c_min == c_max) continue;
+
+        Bin bins[kSAHBins] = {};
+        const float inv_range = kSAHBins / (c_max - c_min);
+        for (uint32_t i = 0; i < inst_count; ++i) {
+            const BVHPrimitiveInfo& info = primitive_info[first_inst + i];
+            int b = (int)((info.centroid[axis] - c_min) * inv_range);
+            if (b >= kSAHBins) b = kSAHBins - 1;
+            bins[b].count++;
+            bins[b].bounds.Expand(info.bounds);
+        }
+
+        BoundBox left_box[kSAHBins - 1];
+        int left_cnt[kSAHBins - 1];
+        {
+            BoundBox cur;
+            int cnt = 0;
+            for (int k = 0; k < kSAHBins - 1; ++k) {
+                cur.Expand(bins[k].bounds);
+                cnt += bins[k].count;
+                left_box[k] = cur;
+                left_cnt[k] = cnt;
+            }
+        }
+
+        BoundBox right_box[kSAHBins - 1];
+        int right_cnt[kSAHBins - 1];
+        {
+            BoundBox cur;
+            int cnt = 0;
+            for (int k = kSAHBins - 1; k >= 1; --k) {
+                cur.Expand(bins[k].bounds);
+                cnt += bins[k].count;
+                right_box[k - 1] = cur;
+                right_cnt[k - 1] = cnt;
+            }
+        }
+
+        const float bin_size = (c_max - c_min) / kSAHBins;
+        for (int k = 0; k < kSAHBins - 1; ++k) {
+            if (left_cnt[k] == 0 || right_cnt[k] == 0) continue;
+            float cost = kCostTraverse + kCostIntersect *
+                                             (left_cnt[k] * left_box[k].HalfArea() +
+                                              right_cnt[k] * right_box[k].HalfArea()) /
+                                             parent_area;
+            if (cost < best_cost) {
+                best_cost = cost;
+                best_axis = axis;
+                best_split = c_min + (k + 1) * bin_size;
+            }
+        }
+    }
+
+    if (best_axis == -1 || best_cost >= leaf_cost) {
+        node.left_first = first_inst;
+        node.tri_count = inst_count;
+        return;
+    }
+
+    auto start_itr = primitive_info.begin() + first_inst;
+    auto end_itr = start_itr + inst_count;
+    auto mid_itr = std::partition(start_itr, end_itr, [&](const BVHPrimitiveInfo& info) {
+        return info.centroid[best_axis] < best_split;
+    });
+
+    uint32_t left_count = (uint32_t)std::distance(start_itr, mid_itr);
+    if (left_count == 0 || left_count == inst_count) {
+        node.left_first = first_inst;
+        node.tri_count = inst_count;
+        return;
+    }
+
+    uint32_t left_child_idx = (uint32_t)nodes_.size();
+    nodes_.emplace_back();
+    nodes_.emplace_back();
+
+    nodes_[node_idx].left_first = left_child_idx;
+    nodes_[node_idx].tri_count = 0;
+
+    Subdivide(left_child_idx, first_inst, left_count, primitive_info, instances);
+    Subdivide(left_child_idx + 1, first_inst + left_count, inst_count - left_count, primitive_info,
+              instances);
+}
+
+bool TLAS::Intersect(const Ray& ray, float t_min, float t_max, SurfaceInteraction* si,
+                     const std::vector<BLAS>& blases,
+                     const std::vector<Instance>& instances) const {
+    if (IsEmpty()) return false;
+
+    bool hit_anything = false;
+    float closest_t = t_max;
+
+    const Vec3& inv_dir = ray.inv_direction();
+    const int dir_is_neg[3] = {inv_dir.x() < 0, inv_dir.y() < 0, inv_dir.z() < 0};
+
+    int nodes_to_visit[64];
+    int to_visit_offset = 0;
+    nodes_to_visit[0] = 0;
+
+    while (to_visit_offset >= 0) {
+        int current_node_idx = nodes_to_visit[to_visit_offset--];
+        const BVHNode& node = nodes_[current_node_idx];
+
+        if (node.bounds.Intersect(ray, t_min, closest_t)) {
+            if (node.tri_count > 0) {
+                for (uint32_t i = 0; i < node.tri_count; ++i) {
+                    const Instance& inst = instances[node.left_first + i];
+                    TRS world_from_local =
+                        inst.is_static ? inst.static_world_from_local
+                                       : EvaluateTransformChain(inst.transform_chain, ray.time());
+                    Ray local_ray(TRSInverseApplyPoint(world_from_local, ray.origin()),
+                                  TRSInverseApplyVector(world_from_local, ray.direction()),
+                                  ray.time());
+                    const BLAS& blas = blases[inst.blas_id];
+                    if (blas.bvh.IsEmpty()) continue;
+
+                    uint32_t tri_idx = 0;
+                    if (blas.bvh.Intersect(local_ray, t_min, closest_t, si, blas.triangles,
+                                           &tri_idx)) {
+                        hit_anything = true;
+                        closest_t = si->t;
+                        TransformHitToWorld(world_from_local, ray, si);
+                        if (tri_idx < inst.tri_light_indices.size()) {
+                            si->light_index = inst.tri_light_indices[tri_idx];
+                        } else {
+                            si->light_index = -1;
+                        }
+                    }
+                }
+            } else {
+                int axis = node.bounds.LongestAxis();
+                if (dir_is_neg[axis]) {
+                    nodes_to_visit[++to_visit_offset] = node.left_first;
+                    nodes_to_visit[++to_visit_offset] = node.left_first + 1;
+                } else {
+                    nodes_to_visit[++to_visit_offset] = node.left_first + 1;
+                    nodes_to_visit[++to_visit_offset] = node.left_first;
+                }
+            }
+        }
+    }
+    return hit_anything;
+}
+
+}  // namespace skwr

--- a/skewer/src/accelerators/tlas.h
+++ b/skewer/src/accelerators/tlas.h
@@ -1,0 +1,33 @@
+#ifndef SKWR_ACCELERATORS_TLAS_H_
+#define SKWR_ACCELERATORS_TLAS_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "accelerators/blas.h"
+#include "accelerators/bvh.h"
+#include "accelerators/instance.h"
+#include "core/ray.h"
+#include "core/transport/surface_interaction.h"
+
+namespace skwr {
+
+class TLAS {
+  public:
+    void Build(std::vector<Instance>& instances);
+
+    bool Intersect(const Ray& ray, float t_min, float t_max, SurfaceInteraction* si,
+                   const std::vector<BLAS>& blases, const std::vector<Instance>& instances) const;
+
+    bool IsEmpty() const { return nodes_.empty(); }
+
+  private:
+    std::vector<BVHNode> nodes_;
+
+    void Subdivide(uint32_t node_idx, uint32_t first_inst, uint32_t inst_count,
+                   std::vector<BVHPrimitiveInfo>& primitive_info, std::vector<Instance>& instances);
+};
+
+}  // namespace skwr
+
+#endif

--- a/skewer/src/accelerators/tlas.h
+++ b/skewer/src/accelerators/tlas.h
@@ -12,6 +12,10 @@
 
 namespace skwr {
 
+// Top-Level Acceleration Structure: a BVH over all scene instances.
+// Each Instance references a BLAS with a transform chain. Traversal finds candidate instances,
+// transforms the ray to local space, intersects the BLAS, then transforms results back to world
+// space.
 class TLAS {
   public:
     void Build(std::vector<Instance>& instances);

--- a/skewer/src/core/math/transform.h
+++ b/skewer/src/core/math/transform.h
@@ -7,6 +7,7 @@
 #include "core/math/quat.h"
 #include "core/math/utils.h"
 #include "core/math/vec3.h"
+#include "geometry/boundbox.h"
 
 namespace skwr {
 
@@ -39,6 +40,31 @@ inline Vec3 TRSApplyPoint(const TRS& trs, const Vec3& p) {
     return trs.translation + QuatRotate(trs.rotation, scaled);
 }
 
+inline Vec3 TRSInverseApplyPoint(const TRS& trs, const Vec3& p) {
+    Vec3 q = p - trs.translation;
+    Vec3 r = QuatRotate(QuatConjugate(trs.rotation), q);
+    float sx = trs.scale.x(), sy = trs.scale.y(), sz = trs.scale.z();
+    if (std::fabs(sx) < Numeric::kNearZeroEpsilon || std::fabs(sy) < Numeric::kNearZeroEpsilon ||
+        std::fabs(sz) < Numeric::kNearZeroEpsilon) {
+        return r;
+    }
+    return Vec3(r.x() / sx, r.y() / sy, r.z() / sz);
+}
+
+inline Vec3 TRSInverseApplyVector(const TRS& trs, const Vec3& v) {
+    Vec3 r = QuatRotate(QuatConjugate(trs.rotation), v);
+    float sx = trs.scale.x(), sy = trs.scale.y(), sz = trs.scale.z();
+    if (std::fabs(sx) < Numeric::kNearZeroEpsilon || std::fabs(sy) < Numeric::kNearZeroEpsilon ||
+        std::fabs(sz) < Numeric::kNearZeroEpsilon) {
+        return r;
+    }
+    return Vec3(r.x() / sx, r.y() / sy, r.z() / sz);
+}
+
+inline Vec3 TRSApplyVector(const TRS& trs, const Vec3& v) {
+    return QuatRotate(trs.rotation, trs.scale * v);
+}
+
 inline Vec3 TRSApplyNormal(const TRS& trs, const Vec3& n) {
     float sx = trs.scale.x(), sy = trs.scale.y(), sz = trs.scale.z();
     if (std::fabs(sx) < Numeric::kNearZeroEpsilon || std::fabs(sy) < Numeric::kNearZeroEpsilon ||
@@ -52,6 +78,20 @@ inline Vec3 TRSApplyNormal(const TRS& trs, const Vec3& n) {
 inline bool TRSIsUniformScale(const TRS& trs, float eps = 1e-5f) {
     float sx = trs.scale.x(), sy = trs.scale.y(), sz = trs.scale.z();
     return std::fabs(sx - sy) <= eps && std::fabs(sy - sz) <= eps;
+}
+
+inline BoundBox TransformBounds(const TRS& trs, const BoundBox& local) {
+    BoundBox world;
+    const Point3& mn = local.min();
+    const Point3& mx = local.max();
+    for (int i = 0; i < 8; ++i) {
+        float x = (i & 1) ? mx.x() : mn.x();
+        float y = (i & 2) ? mx.y() : mn.y();
+        float z = (i & 4) ? mx.z() : mn.z();
+        world.Expand(TRSApplyPoint(trs, Point3(x, y, z)));
+    }
+    world.PadToMinimums();
+    return world;
 }
 
 inline bool TRSIsIdentity(const TRS& trs) {

--- a/skewer/src/core/math/transform.h
+++ b/skewer/src/core/math/transform.h
@@ -40,17 +40,6 @@ inline Vec3 TRSApplyPoint(const TRS& trs, const Vec3& p) {
     return trs.translation + QuatRotate(trs.rotation, scaled);
 }
 
-inline Vec3 TRSInverseApplyPoint(const TRS& trs, const Vec3& p) {
-    Vec3 q = p - trs.translation;
-    Vec3 r = QuatRotate(QuatConjugate(trs.rotation), q);
-    float sx = trs.scale.x(), sy = trs.scale.y(), sz = trs.scale.z();
-    if (std::fabs(sx) < Numeric::kNearZeroEpsilon || std::fabs(sy) < Numeric::kNearZeroEpsilon ||
-        std::fabs(sz) < Numeric::kNearZeroEpsilon) {
-        return r;
-    }
-    return Vec3(r.x() / sx, r.y() / sy, r.z() / sz);
-}
-
 inline Vec3 TRSInverseApplyVector(const TRS& trs, const Vec3& v) {
     Vec3 r = QuatRotate(QuatConjugate(trs.rotation), v);
     float sx = trs.scale.x(), sy = trs.scale.y(), sz = trs.scale.z();
@@ -59,6 +48,11 @@ inline Vec3 TRSInverseApplyVector(const TRS& trs, const Vec3& v) {
         return r;
     }
     return Vec3(r.x() / sx, r.y() / sy, r.z() / sz);
+}
+
+inline Vec3 TRSInverseApplyPoint(const TRS& trs, const Vec3& p) {
+    Vec3 q = p - trs.translation;
+    return TRSInverseApplyVector(trs, q);
 }
 
 inline Vec3 TRSApplyVector(const TRS& trs, const Vec3& v) {

--- a/skewer/src/core/ray.h
+++ b/skewer/src/core/ray.h
@@ -8,12 +8,10 @@ namespace skwr {
 
 class Ray {
   public:
-    Ray() {}
+    Ray() : tm_(0.0f) {}
 
-    // Ray(const Point3& origin, const Vec3& direction, double time)
-    //     : orig(origin), dir(direction), tm(time) {}
-
-    Ray(const Point3& origin, const Vec3& direction) : orig_(origin), dir_(direction) {
+    Ray(const Point3& origin, const Vec3& direction, float time = 0.0f)
+        : orig_(origin), dir_(direction), tm_(time) {
         // Precompute inverse optimization
         // IEEE 754 floating point handles 1.0/0.0 as Infinity, which works
         // correctly with the slab method intersection logic.
@@ -26,7 +24,7 @@ class Ray {
     const Vec3& inv_direction() const { return inv_dir_; }
     const VolumeStack& vol_stack() const { return vol_stack_; }
     VolumeStack& vol_stack() { return vol_stack_; }
-    // double time() const { return tm_; }
+    float time() const { return tm_; }
 
     // 3D pos (P) on Ray is function of P(t) = A + tb, A = origin, b = Ray direction
     Point3 at(double t) const { return orig_ + t * dir_; }
@@ -36,7 +34,7 @@ class Ray {
     Vec3 dir_;
     Vec3 inv_dir_;
     VolumeStack vol_stack_;  // 17 bytes. TODO: move to PathState struct when DDGeom
-    // double tm_;
+    float tm_;
 };
 
 }  // namespace skwr

--- a/skewer/src/geometry/animated_sphere.h
+++ b/skewer/src/geometry/animated_sphere.h
@@ -1,0 +1,51 @@
+#ifndef SKWR_GEOMETRY_ANIMATED_SPHERE_H_
+#define SKWR_GEOMETRY_ANIMATED_SPHERE_H_
+
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+
+#include "geometry/sphere.h"
+#include "scene/animation.h"
+#include "scene/scene_graph.h"
+
+namespace skwr {
+
+struct AnimatedSphere {
+    SphereData local_data{};
+    std::vector<AnimatedTransform> transform_chain;
+    int32_t emissive_light_index = -1;
+
+    Sphere EvaluateAt(float t) const {
+        if (local_data.center_is_world) {
+            if (!transform_chain.empty()) {
+                throw std::runtime_error(
+                    "AnimatedSphere: world-space center requires empty transform chain");
+            }
+            return Sphere{local_data.center,
+                          local_data.radius,
+                          local_data.material_id,
+                          emissive_light_index >= 0 ? emissive_light_index : local_data.light_index,
+                          local_data.interior_medium,
+                          local_data.exterior_medium,
+                          local_data.priority};
+        }
+        TRS w = EvaluateTransformChain(transform_chain, t);
+        if (!TRSIsUniformScale(w)) {
+            throw std::runtime_error("Animated sphere requires uniform scale");
+        }
+        Vec3 c = TRSApplyPoint(w, local_data.center);
+        float r = local_data.radius * std::fabs(w.scale.x());
+        return Sphere{c,
+                      r,
+                      local_data.material_id,
+                      emissive_light_index >= 0 ? emissive_light_index : local_data.light_index,
+                      local_data.interior_medium,
+                      local_data.exterior_medium,
+                      local_data.priority};
+    }
+};
+
+}  // namespace skwr
+
+#endif

--- a/skewer/src/io/scene_loader.cc
+++ b/skewer/src/io/scene_loader.cc
@@ -521,6 +521,8 @@ SceneConfig LoadSceneFile(const std::string& filepath) {
     config.vfov = GetOr(cam, "vfov", 90.0f);
     config.aperture_radius = GetOr(cam, "aperture_radius", 0.0f);
     config.focus_distance = GetOr(cam, "focus_distance", 1.0f);
+    config.shutter_open = GetOr(cam, "shutter_open", 0.0f);
+    config.shutter_close = GetOr(cam, "shutter_close", 0.0f);
 
     // Output directory (local path or cloud URI — used as-is, not resolved)
     config.output_dir = GetOr<std::string>(j, "output_dir", "");

--- a/skewer/src/io/scene_loader.h
+++ b/skewer/src/io/scene_loader.h
@@ -34,6 +34,8 @@ struct SceneConfig {
     float vfov = 90.0f;
     float aperture_radius = 0.0f;
     float focus_distance = 1.0f;
+    float shutter_open = 0.0f;
+    float shutter_close = 0.0f;
 
     // Context layer paths (resolved to absolute paths)
     std::vector<std::string> context_paths;

--- a/skewer/src/kernels/path_kernel.cc
+++ b/skewer/src/kernels/path_kernel.cc
@@ -91,7 +91,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
             /* Volume Next Event Estimation (Direct Lighting) */
             DirectLightSample dls;
             if (GenerateLightSample(mi.point, scene, rng, wl, &dls)) {
-                Ray shadow_ray(mi.point, dls.wi);
+                Ray shadow_ray(mi.point, dls.wi, r.time());
                 shadow_ray.vol_stack() = r.vol_stack();
 
                 Spectrum Tr = EvaluateVisibility(scene, shadow_ray, dls.dist, rng, wl);
@@ -122,7 +122,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
             // Note: For Henyey-Greenstein, the phase_eval / phase_pdf ratio is EXACTLY 1.0
             // The sampling routine perfectly importance samples the distribution so beta is
             // unchanged by the directional scatter itself
-            Ray next_r(mi.point, next_wi);
+            Ray next_r(mi.point, next_wi, r.time());
             next_r.vol_stack() = r.vol_stack();
             r = next_r;
             specular_bounce = false;
@@ -145,7 +145,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
             // SHADING POLICY (Opacity & BSDF)
             if (si.material_id == kNullMaterialId) {
                 Ray next_ray(si.point + (r.direction() * RenderConstants::kRayOffsetEpsilon),
-                             r.direction());
+                             r.direction(), r.time());
                 next_ray.vol_stack() = r.vol_stack();
                 r = next_ray;
                 depth--;
@@ -207,8 +207,8 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
                 if (GenerateLightSample(
                         si.point + (si.n_shading * RenderConstants::kRayOffsetEpsilon), scene, rng,
                         wl, &dls)) {
-                    Ray shadow_ray(si.point + (dls.wi * RenderConstants::kRayOffsetEpsilon),
-                                   dls.wi);
+                    Ray shadow_ray(si.point + (dls.wi * RenderConstants::kRayOffsetEpsilon), dls.wi,
+                                   r.time());
                     shadow_ray.vol_stack() = r.vol_stack();
 
                     Spectrum Tr = EvaluateVisibility(scene, shadow_ray, dls.dist, rng, wl);
@@ -249,7 +249,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
 
                     prev_scatter_pdf = pdf;
                     beta *= weight;
-                    Ray next_r(si.point + (wi * RenderConstants::kRayOffsetEpsilon), wi);
+                    Ray next_r(si.point + (wi * RenderConstants::kRayOffsetEpsilon), wi, r.time());
                     next_r.vol_stack() = r.vol_stack();
 
                     // Update is_camera_path based on transmission

--- a/skewer/src/kernels/utils/visibility.cc
+++ b/skewer/src/kernels/utils/visibility.cc
@@ -57,7 +57,7 @@ Spectrum EvaluateVisibility(const Scene& scene, Ray& ray, float max_dist, RNG& r
             // Advance the shadow ray past the surface
             Ray next_ray(
                 shadow_si.point + (shadow_ray.direction() * RenderConstants::kRayOffsetEpsilon),
-                shadow_ray.direction());
+                shadow_ray.direction(), shadow_ray.time());
             next_ray.vol_stack() = shadow_ray.vol_stack();
             shadow_ray = next_ray;
             remaining_dist -= shadow_si.t;

--- a/skewer/src/scene/animation.h
+++ b/skewer/src/scene/animation.h
@@ -27,6 +27,23 @@ struct AnimatedTransform {
     void SortKeyframes();
 };
 
+inline TRS EvaluateTransformChain(const std::vector<AnimatedTransform>& chain, float t) {
+    TRS acc{};
+    for (const auto& at : chain) {
+        acc = Compose(acc, at.Evaluate(t));
+    }
+    return acc;
+}
+
+inline bool TransformChainIsStatic(const std::vector<AnimatedTransform>& chain) {
+    for (const auto& at : chain) {
+        if (!at.IsStatic()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 }  // namespace skwr
 
 #endif

--- a/skewer/src/scene/camera.h
+++ b/skewer/src/scene/camera.h
@@ -16,7 +16,9 @@ namespace skwr {
 class Camera {
   public:
     Camera(const Vec3& look_from, const Vec3& look_at, const Vec3& vup, float vfov,
-           float aspect_ratio, float aperture_radius = 0.0f, float focus_distance = 1.0f) {
+           float aspect_ratio, float aperture_radius = 0.0f, float focus_distance = 1.0f,
+           float shutter_open = 0.0f, float shutter_close = 0.0f)
+        : shutter_open_(shutter_open), shutter_close_(shutter_close) {
         auto theta = vfov * MathConstants::kPi / 180.0f;
         auto h = std::tan(theta / 2.0f);
         auto viewport_height = 2.0f * h;
@@ -47,7 +49,9 @@ class Camera {
             offset = u_ * rd.x() + v_ * rd.y();
         }
         Vec3 focal_point = lower_left_corner_ + horizontal_ * s + vertical_ * t;
-        return Ray(origin_ + offset, Normalize(focal_point - origin_ - offset));
+        Vec3 dir = Normalize(focal_point - origin_ - offset);
+        float ray_time = shutter_open_ + rng.UniformFloat() * (shutter_close_ - shutter_open_);
+        return Ray(origin_ + offset, dir, ray_time);
     }
 
     Vec3 GetW() const { return w_; }
@@ -60,6 +64,8 @@ class Camera {
     Vec3 vertical_;
     Vec3 u_, v_, w_;
     float lens_radius_ = 0.0f;
+    float shutter_open_ = 0.0f;
+    float shutter_close_ = 0.0f;
 };
 
 }  // namespace skwr

--- a/skewer/src/scene/light.cc
+++ b/skewer/src/scene/light.cc
@@ -10,11 +10,11 @@ float LightPdfArea(const Scene& scene, int light_index) {
     const AreaLight& light = scene.Lights()[light_index];
 
     if (light.type == AreaLight::Sphere) {
-        const Sphere& s = scene.Spheres()[light.primitive_index];
+        const Sphere& s = scene.LightSpheres()[light.primitive_index];
         float area = 4.0f * MathConstants::kPi * s.radius * s.radius;
         return 1.0f / area;
     } else if (light.type == AreaLight::Triangle) {
-        const Triangle& t = scene.Triangles()[light.primitive_index];
+        const Triangle& t = scene.LightTriangles()[light.primitive_index];
         float area = 0.5f * Cross(t.e1, t.e2).Length();
         return (area > 0.0f) ? 1.0f / area : 0.0f;
     }
@@ -27,7 +27,7 @@ LightSample SampleLight(const Scene& scene, int light_index, RNG& rng) {
     result.emission = light.emission;
 
     if (light.type == AreaLight::Sphere) {
-        const Sphere& s = scene.Spheres()[light.primitive_index];
+        const Sphere& s = scene.LightSpheres()[light.primitive_index];
 
         Vec3 random_point = RandomUnitVector(rng);
         result.p = s.center + random_point * s.radius;
@@ -35,7 +35,7 @@ LightSample SampleLight(const Scene& scene, int light_index, RNG& rng) {
 
         result.pdf = LightPdfArea(scene, light_index);
     } else if (light.type == AreaLight::Triangle) {
-        const Triangle& t = scene.Triangles()[light.primitive_index];
+        const Triangle& t = scene.LightTriangles()[light.primitive_index];
 
         // Uniform sample on triangle (sqrt trick for uniform distribution)
         float r1 = rng.UniformFloat();

--- a/skewer/src/scene/light.h
+++ b/skewer/src/scene/light.h
@@ -12,7 +12,7 @@ class Scene;
 // A lightweight reference to an emissive primitive in the Scene
 struct AreaLight {
     enum Type { Sphere, Triangle } type;
-    uint32_t primitive_index;  // Index into scene.spheres_ or scene.meshes_
+    uint32_t primitive_index;  // Index into scene.LightSpheres() or scene.LightTriangles()
     SpectralCurve emission;    // cache the emission
     // BoundBox bounds;           // Bounding Box for optimization
 };

--- a/skewer/src/scene/scene.cc
+++ b/skewer/src/scene/scene.cc
@@ -23,7 +23,7 @@ namespace skwr {
 namespace {
 
 Triangle TransformTriangleToWorld(const TRS& trs, const Triangle& L) {
-    Triangle W;
+    Triangle W = L;
     W.p0 = TRSApplyPoint(trs, L.p0);
     Vec3 p1 = TRSApplyPoint(trs, L.p0 + L.e1);
     Vec3 p2 = TRSApplyPoint(trs, L.p0 + L.e2);
@@ -32,15 +32,7 @@ Triangle TransformTriangleToWorld(const TRS& trs, const Triangle& L) {
     W.n0 = TRSApplyNormal(trs, L.n0);
     W.n1 = TRSApplyNormal(trs, L.n1);
     W.n2 = TRSApplyNormal(trs, L.n2);
-    W.uv0 = L.uv0;
-    W.uv1 = L.uv1;
-    W.uv2 = L.uv2;
-    W.material_id = L.material_id;
     W.light_index = -1;
-    W.interior_medium = L.interior_medium;
-    W.exterior_medium = L.exterior_medium;
-    W.priority = L.priority;
-    W.needs_tangent_frame = L.needs_tangent_frame;
     return W;
 }
 
@@ -128,19 +120,18 @@ uint32_t Scene::EnsureBlasForMesh(uint32_t mesh_id,
     return id;
 }
 
-void Scene::ExtractInstancesFromGraph(const SceneNode& node,
-                                      std::vector<AnimatedTransform> prefix) {
+void Scene::ExtractInstancesFromGraph(const SceneNode& node, std::vector<AnimatedTransform> prefix,
+                                      std::unordered_map<uint32_t, uint32_t>& mesh_to_blas) {
     std::vector<AnimatedTransform> chain = prefix;
     chain.push_back(node.anim_transform);
 
     switch (node.type) {
         case NodeType::Group:
             for (const SceneNode& ch : node.children) {
-                ExtractInstancesFromGraph(ch, chain);
+                ExtractInstancesFromGraph(ch, chain, mesh_to_blas);
             }
             break;
         case NodeType::Mesh: {
-            std::unordered_map<uint32_t, uint32_t> mesh_to_blas;
             for (uint32_t mesh_id : node.mesh_ids) {
                 uint32_t blas_id = EnsureBlasForMesh(mesh_id, mesh_to_blas);
                 if (blases_[blas_id].triangles.empty()) {
@@ -281,7 +272,8 @@ void Scene::Build() {
 
     if (graph_root_) {
         spheres_.clear();
-        ExtractInstancesFromGraph(*graph_root_, {});
+        std::unordered_map<uint32_t, uint32_t> mesh_to_blas;
+        ExtractInstancesFromGraph(*graph_root_, {}, mesh_to_blas);
         graph_root_.reset();
 
         float mid_t = 0.5f * (shutter_open_ + shutter_close_);

--- a/skewer/src/scene/scene.cc
+++ b/skewer/src/scene/scene.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <iostream>
 #include <stdexcept>
 
 #include "accelerators/bvh.h"
@@ -19,6 +20,32 @@
 
 namespace skwr {
 
+namespace {
+
+Triangle TransformTriangleToWorld(const TRS& trs, const Triangle& L) {
+    Triangle W;
+    W.p0 = TRSApplyPoint(trs, L.p0);
+    Vec3 p1 = TRSApplyPoint(trs, L.p0 + L.e1);
+    Vec3 p2 = TRSApplyPoint(trs, L.p0 + L.e2);
+    W.e1 = p1 - W.p0;
+    W.e2 = p2 - W.p0;
+    W.n0 = TRSApplyNormal(trs, L.n0);
+    W.n1 = TRSApplyNormal(trs, L.n1);
+    W.n2 = TRSApplyNormal(trs, L.n2);
+    W.uv0 = L.uv0;
+    W.uv1 = L.uv1;
+    W.uv2 = L.uv2;
+    W.material_id = L.material_id;
+    W.light_index = -1;
+    W.interior_medium = L.interior_medium;
+    W.exterior_medium = L.exterior_medium;
+    W.priority = L.priority;
+    W.needs_tangent_frame = L.needs_tangent_frame;
+    return W;
+}
+
+}  // namespace
+
 void Scene::MergeGraphRoots(std::vector<SceneNode>&& roots) {
     if (roots.empty()) {
         return;
@@ -35,90 +62,147 @@ void Scene::MergeGraphRoots(std::vector<SceneNode>&& roots) {
     }
 }
 
-void Scene::FlattenGraph(const SceneNode& node, const TRS& parent_world) {
-    TRS local = node.anim_transform.Evaluate(0.0f);
-    TRS world = Compose(parent_world, local);
+uint32_t Scene::EnsureBlasForMesh(uint32_t mesh_id,
+                                  std::unordered_map<uint32_t, uint32_t>& mesh_to_blas) {
+    auto it = mesh_to_blas.find(mesh_id);
+    if (it != mesh_to_blas.end()) {
+        return it->second;
+    }
+
+    const Mesh& mesh_ref = meshes_[mesh_id];
+    std::vector<Triangle> local_tris;
+    const Material* mat =
+        (mesh_ref.material_id != kNullMaterialId) ? &materials_[mesh_ref.material_id] : nullptr;
+
+    for (size_t i = 0; i < mesh_ref.indices.size(); i += 3) {
+        uint32_t i0 = mesh_ref.indices[i];
+        uint32_t i1 = mesh_ref.indices[i + 1];
+        uint32_t i2 = mesh_ref.indices[i + 2];
+
+        Triangle t;
+        t.p0 = mesh_ref.p[i0];
+        t.e1 = mesh_ref.p[i1] - t.p0;
+        t.e2 = mesh_ref.p[i2] - t.p0;
+        t.material_id = mesh_ref.material_id;
+        t.interior_medium = kVacuumMediumId;
+        t.exterior_medium = kVacuumMediumId;
+        t.priority = 0;
+        t.needs_tangent_frame = mat != nullptr && mat->HasNormalMap();
+
+        if (!mesh_ref.n.empty()) {
+            t.n0 = mesh_ref.n[i0];
+            t.n1 = mesh_ref.n[i1];
+            t.n2 = mesh_ref.n[i2];
+        } else {
+            Vec3 geom_n = Normalize(Cross(t.e1, t.e2));
+            t.n0 = t.n1 = t.n2 = geom_n;
+        }
+
+        if (!mesh_ref.uv.empty()) {
+            t.uv0 = mesh_ref.uv[i0];
+            t.uv1 = mesh_ref.uv[i1];
+            t.uv2 = mesh_ref.uv[i2];
+        } else {
+            t.uv0 = t.uv1 = t.uv2 = Vec3(0.0f, 0.0f, 0.0f);
+        }
+
+        local_tris.push_back(t);
+    }
+
+    BLAS blas;
+    blas.triangles = std::move(local_tris);
+    blas.local_bounds = BoundBox();
+    for (const auto& tri : blas.triangles) {
+        blas.local_bounds.Expand(tri.p0);
+        blas.local_bounds.Expand(tri.p0 + tri.e1);
+        blas.local_bounds.Expand(tri.p0 + tri.e2);
+    }
+    if (!blas.triangles.empty()) {
+        blas.local_bounds.PadToMinimums();
+        blas.bvh.Build(blas.triangles);
+    }
+
+    uint32_t id = static_cast<uint32_t>(blases_.size());
+    blases_.push_back(std::move(blas));
+    mesh_to_blas[mesh_id] = id;
+    return id;
+}
+
+void Scene::ExtractInstancesFromGraph(const SceneNode& node,
+                                      std::vector<AnimatedTransform> prefix) {
+    std::vector<AnimatedTransform> chain = prefix;
+    chain.push_back(node.anim_transform);
 
     switch (node.type) {
         case NodeType::Group:
             for (const SceneNode& ch : node.children) {
-                FlattenGraph(ch, world);
+                ExtractInstancesFromGraph(ch, chain);
             }
             break;
-        case NodeType::Mesh:
+        case NodeType::Mesh: {
+            std::unordered_map<uint32_t, uint32_t> mesh_to_blas;
             for (uint32_t mesh_id : node.mesh_ids) {
-                if (TRSIsIdentity(world)) {
+                uint32_t blas_id = EnsureBlasForMesh(mesh_id, mesh_to_blas);
+                if (blases_[blas_id].triangles.empty()) {
                     continue;
                 }
-                Mesh& mesh = GetMutableMesh(mesh_id);
-                for (Vec3& v : mesh.p) {
-                    v = TRSApplyPoint(world, v);
+                Instance inst;
+                inst.blas_id = blas_id;
+                inst.transform_chain = chain;
+                inst.is_static = TransformChainIsStatic(chain);
+                inst.static_world_from_local =
+                    inst.is_static ? EvaluateTransformChain(chain, 0.0f) : TRS{};
+                const BoundBox& lb = blases_[blas_id].local_bounds;
+                if (inst.is_static) {
+                    inst.world_bounds = TransformBounds(inst.static_world_from_local, lb);
+                } else {
+                    TRS a = EvaluateTransformChain(chain, shutter_open_);
+                    TRS b = EvaluateTransformChain(chain, shutter_close_);
+                    inst.world_bounds = Union(TransformBounds(a, lb), TransformBounds(b, lb));
                 }
-                if (!mesh.n.empty()) {
-                    for (Vec3& n : mesh.n) {
-                        n = TRSApplyNormal(world, n);
-                    }
-                }
+                inst.tri_light_indices.assign(blases_[blas_id].triangles.size(), -1);
+                instances_.push_back(std::move(inst));
             }
             break;
+        }
         case NodeType::Sphere: {
             if (!node.sphere_data.has_value()) {
                 throw std::runtime_error("Sphere node missing sphere_data");
             }
             const SphereData& sd = *node.sphere_data;
             if (sd.center_is_world) {
-                if (!TRSIsIdentity(world)) {
+                TRS w = EvaluateTransformChain(chain, 0.0f);
+                if (!TRSIsIdentity(w)) {
                     throw std::runtime_error(
                         "Sphere with world-space center (e.g. NanoVDB) requires identity world "
                         "transform");
                 }
                 AddSphere(Sphere{sd.center, sd.radius, sd.material_id, sd.light_index,
                                  sd.interior_medium, sd.exterior_medium, sd.priority});
-            } else {
-                if (!TRSIsUniformScale(world)) {
+            } else if (TransformChainIsStatic(chain)) {
+                TRS w = EvaluateTransformChain(chain, 0.0f);
+                if (!TRSIsUniformScale(w)) {
                     throw std::runtime_error(
                         "Sphere requires uniform scale; non-uniform world scale is not supported");
                 }
-                float s = world.scale.x();
-                Vec3 c = TRSApplyPoint(world, sd.center);
-                float r = sd.radius * std::fabs(s);
+                float sc = w.scale.x();
+                Vec3 c = TRSApplyPoint(w, sd.center);
+                float r = sd.radius * std::fabs(sc);
                 AddSphere(Sphere{c, r, sd.material_id, sd.light_index, sd.interior_medium,
                                  sd.exterior_medium, sd.priority});
+            } else {
+                AnimatedSphere asphere;
+                asphere.local_data = sd;
+                asphere.transform_chain = chain;
+                animated_spheres_.push_back(std::move(asphere));
             }
             break;
         }
     }
 }
 
-void Scene::Build() {
-    if (graph_root_) {
-        FlattenGraph(*graph_root_, TRS{});
-        graph_root_.reset();
-    }
-
-    triangles_.clear();
-    lights_.clear();
-
-    // Re-register sphere lights
-    for (uint32_t i = 0; i < (uint32_t)spheres_.size(); ++i) {
-        spheres_[i].light_index = -1;
-        if (spheres_[i].material_id == kNullMaterialId) continue;
-
-        const Material& mat = materials_[spheres_[i].material_id];
-        if (mat.IsEmissive()) {
-            AreaLight light;
-            light.type = AreaLight::Sphere;
-            light.primitive_index = i;
-            light.emission = mat.emission;
-            lights_.push_back(light);
-            spheres_[i].light_index = static_cast<int32_t>(lights_.size() - 1);
-        }
-    }
-
-    // TODO: Update triangle creation with in/out medium setting
-    // Bake one Triangle per mesh face, capturing final vertex positions,
-    // edges, normals, and material_id from the fully-prepared Mesh objects.
-    for (uint32_t mesh_id = 0; mesh_id < (uint32_t)meshes_.size(); ++mesh_id) {
+void Scene::BuildLegacyMeshBvhAndLights() {
+    for (uint32_t mesh_id = 0; mesh_id < static_cast<uint32_t>(meshes_.size()); ++mesh_id) {
         const Mesh& mesh_ref = meshes_[mesh_id];
         const Material* mat =
             (mesh_ref.material_id != kNullMaterialId) ? &materials_[mesh_ref.material_id] : nullptr;
@@ -164,34 +248,166 @@ void Scene::Build() {
         bvh_.Build(triangles_);
     }
 
-    for (uint32_t i = 0; i < (uint32_t)triangles_.size(); ++i) {
+    for (uint32_t i = 0; i < static_cast<uint32_t>(triangles_.size()); ++i) {
         const Material* mat = (triangles_[i].material_id != kNullMaterialId)
                                   ? &materials_[triangles_[i].material_id]
                                   : nullptr;
         if (mat != nullptr && mat->IsEmissive()) {
+            Triangle lt = triangles_[i];
+            uint32_t light_idx = static_cast<uint32_t>(lights_.size());
+            lt.light_index = static_cast<int32_t>(light_idx);
+            light_triangles_.push_back(lt);
             AreaLight light;
             light.type = AreaLight::Triangle;
-            light.primitive_index = i;
+            light.primitive_index = static_cast<uint32_t>(light_triangles_.size() - 1);
             light.emission = mat->emission;
             lights_.push_back(light);
-            triangles_[i].light_index = static_cast<int32_t>(lights_.size() - 1);
+            triangles_[i].light_index = static_cast<int32_t>(light_idx);
         }
     }
+}
+
+void Scene::Build() {
+    triangles_.clear();
+    lights_.clear();
+    light_triangles_.clear();
+    light_spheres_.clear();
+    inv_light_count_ = 0.0f;
+    instances_.clear();
+    blases_.clear();
+    tlas_ = TLAS{};
+    bvh_ = BVH{};
+    animated_spheres_.clear();
+
+    if (graph_root_) {
+        spheres_.clear();
+        ExtractInstancesFromGraph(*graph_root_, {});
+        graph_root_.reset();
+
+        float mid_t = 0.5f * (shutter_open_ + shutter_close_);
+
+        for (uint32_t i = 0; i < static_cast<uint32_t>(spheres_.size()); ++i) {
+            spheres_[i].light_index = -1;
+            if (spheres_[i].material_id == kNullMaterialId) {
+                continue;
+            }
+            const Material& mat = materials_[spheres_[i].material_id];
+            if (mat.IsEmissive()) {
+                light_spheres_.push_back(spheres_[i]);
+                AreaLight light;
+                light.type = AreaLight::Sphere;
+                light.primitive_index = static_cast<uint32_t>(light_spheres_.size() - 1);
+                light.emission = mat.emission;
+                lights_.push_back(light);
+                int32_t li = static_cast<int32_t>(lights_.size() - 1);
+                light_spheres_.back().light_index = li;
+                spheres_[i].light_index = li;
+            }
+        }
+
+        for (AnimatedSphere& as : animated_spheres_) {
+            Sphere s_mid = as.EvaluateAt(mid_t);
+            if (s_mid.material_id == kNullMaterialId) {
+                continue;
+            }
+            const Material& mat = materials_[s_mid.material_id];
+            if (mat.IsEmissive()) {
+                light_spheres_.push_back(s_mid);
+                AreaLight light;
+                light.type = AreaLight::Sphere;
+                light.primitive_index = static_cast<uint32_t>(light_spheres_.size() - 1);
+                light.emission = mat.emission;
+                lights_.push_back(light);
+                as.emissive_light_index = static_cast<int32_t>(lights_.size() - 1);
+                light_spheres_.back().light_index = as.emissive_light_index;
+            }
+        }
+
+        for (Instance& inst : instances_) {
+            inst.first_light_index = static_cast<uint32_t>(lights_.size());
+            inst.light_count = 0;
+            const BLAS& blas = blases_[inst.blas_id];
+            TRS mid = inst.is_static ? inst.static_world_from_local
+                                     : EvaluateTransformChain(inst.transform_chain, mid_t);
+            for (size_t ti = 0; ti < blas.triangles.size(); ++ti) {
+                const Triangle& lt = blas.triangles[ti];
+                if (lt.material_id == kNullMaterialId) {
+                    continue;
+                }
+                const Material& mat = materials_[lt.material_id];
+                if (!mat.IsEmissive()) {
+                    continue;
+                }
+                Triangle wt = TransformTriangleToWorld(mid, lt);
+                uint32_t li = static_cast<uint32_t>(lights_.size());
+                wt.light_index = static_cast<int32_t>(li);
+                light_triangles_.push_back(wt);
+                AreaLight L;
+                L.type = AreaLight::Triangle;
+                L.primitive_index = static_cast<uint32_t>(light_triangles_.size() - 1);
+                L.emission = mat.emission;
+                lights_.push_back(L);
+                inst.tri_light_indices[ti] = static_cast<int32_t>(li);
+                inst.light_count++;
+            }
+        }
+
+        if (!instances_.empty()) {
+            std::cout << "Building TLAS for " << instances_.size() << " instances...\n";
+            tlas_.Build(instances_);
+        }
+    } else {
+        for (uint32_t i = 0; i < static_cast<uint32_t>(spheres_.size()); ++i) {
+            spheres_[i].light_index = -1;
+            if (spheres_[i].material_id == kNullMaterialId) {
+                continue;
+            }
+            const Material& mat = materials_[spheres_[i].material_id];
+            if (mat.IsEmissive()) {
+                light_spheres_.push_back(spheres_[i]);
+                AreaLight light;
+                light.type = AreaLight::Sphere;
+                light.primitive_index = static_cast<uint32_t>(light_spheres_.size() - 1);
+                light.emission = mat.emission;
+                lights_.push_back(light);
+                int32_t li = static_cast<int32_t>(lights_.size() - 1);
+                light_spheres_.back().light_index = li;
+                spheres_[i].light_index = li;
+            }
+        }
+        BuildLegacyMeshBvhAndLights();
+    }
+
     inv_light_count_ = lights_.empty() ? 0.0f : 1.0f / static_cast<float>(lights_.size());
 }
 
 bool Scene::Intersect(const Ray& r, float t_min, float t_max, SurfaceInteraction* si) const {
     bool hit_anything = false;
     float closest_t = t_max;
-    for (const auto& sphere : spheres_) {
+
+    for (const AnimatedSphere& asphere : animated_spheres_) {
+        Sphere s = asphere.EvaluateAt(r.time());
+        if (IntersectSphere(r, s, t_min, closest_t, si)) {
+            hit_anything = true;
+            closest_t = si->t;
+        }
+    }
+
+    for (const Sphere& sphere : spheres_) {
         if (IntersectSphere(r, sphere, t_min, closest_t, si)) {
             hit_anything = true;
             closest_t = si->t;
         }
     }
 
-    if (bvh_.Intersect(r, t_min, closest_t, si, Triangles())) {
-        hit_anything = true;
+    if (!tlas_.IsEmpty()) {
+        if (tlas_.Intersect(r, t_min, closest_t, si, blases_, instances_)) {
+            hit_anything = true;
+        }
+    } else if (!bvh_.IsEmpty()) {
+        if (bvh_.Intersect(r, t_min, closest_t, si, triangles_)) {
+            hit_anything = true;
+        }
     }
 
     return hit_anything;
@@ -199,7 +415,7 @@ bool Scene::Intersect(const Ray& r, float t_min, float t_max, SurfaceInteraction
 
 uint32_t Scene::AddSphere(const Sphere& s) {
     spheres_.push_back(s);
-    return (uint32_t)spheres_.size() - 1;
+    return static_cast<uint32_t>(spheres_.size() - 1);
 }
 
 uint32_t Scene::AddMaterial(const Material& m) {
@@ -209,7 +425,7 @@ uint32_t Scene::AddMaterial(const Material& m) {
 
 uint32_t Scene::AddMesh(Mesh&& m) {
     meshes_.push_back(std::move(m));
-    return (uint32_t)meshes_.size() - 1;
+    return static_cast<uint32_t>(meshes_.size() - 1);
 }
 
 uint32_t Scene::AddTexture(ImageTexture&& t) {
@@ -219,7 +435,7 @@ uint32_t Scene::AddTexture(ImageTexture&& t) {
 
 uint16_t Scene::AddHomogeneousMedium(const HomogeneousMedium& m) {
     if (homogeneous_media_.size() >= static_cast<size_t>(kMediumIndexMask) + 1u) {
-        return kVacuumMediumId;  // or assert / throw
+        return kVacuumMediumId;
     }
     homogeneous_media_.push_back(m);
     uint16_t index = static_cast<uint16_t>(homogeneous_media_.size() - 1);
@@ -228,7 +444,7 @@ uint16_t Scene::AddHomogeneousMedium(const HomogeneousMedium& m) {
 
 uint16_t Scene::AddGridMedium(const GridMedium& m) {
     if (grid_media_.size() >= static_cast<size_t>(kMediumIndexMask) + 1u) {
-        return kVacuumMediumId;  // or assert / throw
+        return kVacuumMediumId;
     }
     grid_media_.push_back(m);
     uint16_t index = static_cast<uint16_t>(grid_media_.size() - 1);
@@ -237,7 +453,7 @@ uint16_t Scene::AddGridMedium(const GridMedium& m) {
 
 uint16_t Scene::AddNanoVDBMedium(NanoVDBMedium m) {
     if (nanovdb_media_.size() >= static_cast<size_t>(kMediumIndexMask) + 1u) {
-        return kVacuumMediumId;  // or assert / throw
+        return kVacuumMediumId;
     }
     nanovdb_media_.push_back(std::move(m));
     uint16_t index = static_cast<uint16_t>(nanovdb_media_.size() - 1);

--- a/skewer/src/scene/scene.h
+++ b/skewer/src/scene/scene.h
@@ -73,7 +73,8 @@ class Scene {
     bool Intersect(const Ray& r, float t_min, float t_max, SurfaceInteraction* si) const;
 
   private:
-    void ExtractInstancesFromGraph(const SceneNode& node, std::vector<AnimatedTransform> prefix);
+    void ExtractInstancesFromGraph(const SceneNode& node, std::vector<AnimatedTransform> prefix,
+                                   std::unordered_map<uint32_t, uint32_t>& mesh_to_blas);
     uint32_t EnsureBlasForMesh(uint32_t mesh_id,
                                std::unordered_map<uint32_t, uint32_t>& mesh_to_blas);
     void BuildLegacyMeshBvhAndLights();

--- a/skewer/src/scene/scene.h
+++ b/skewer/src/scene/scene.h
@@ -5,9 +5,14 @@
 
 #include <cstdint>
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
+#include "accelerators/blas.h"
 #include "accelerators/bvh.h"
+#include "accelerators/instance.h"
+#include "accelerators/tlas.h"
+#include "geometry/animated_sphere.h"
 #include "geometry/mesh.h"
 #include "geometry/sphere.h"
 #include "geometry/triangle.h"
@@ -45,6 +50,8 @@ class Scene {
     size_t MeshCount() const { return meshes_.size(); }
     const std::vector<Sphere>& Spheres() const { return spheres_; }
     const std::vector<Triangle>& Triangles() const { return triangles_; }
+    const std::vector<Triangle>& LightTriangles() const { return light_triangles_; }
+    const std::vector<Sphere>& LightSpheres() const { return light_spheres_; }
     const std::vector<Material>& Materials() const { return materials_; }
     const std::vector<AreaLight>& Lights() const { return lights_; }
     const std::vector<HomogeneousMedium>& homogeneous_media() const { return homogeneous_media_; }
@@ -52,32 +59,45 @@ class Scene {
     const std::vector<NanoVDBMedium>& nanovdb_media() const { return nanovdb_media_; }
     const float& InvLightCount() const { return inv_light_count_; }
 
-    void Build();  // Flatten scene graph (if any), then construct the BVH from the shapes list
+    void SetShutter(float open, float close) {
+        shutter_open_ = open;
+        shutter_close_ = close;
+    }
+
+    void Build();
 
     void MergeGraphRoots(std::vector<SceneNode>&& roots);
 
     bool HasGraph() const { return graph_root_.has_value(); }
 
-    // THE CRITICAL HOT-PATH FUNCTION
-    // The Integrator calls this millions of times.
-    // rn loops through linearly, but when BVH is implemented, should be faster
     bool Intersect(const Ray& r, float t_min, float t_max, SurfaceInteraction* si) const;
 
   private:
-    void FlattenGraph(const SceneNode& node, const TRS& parent_world);
+    void ExtractInstancesFromGraph(const SceneNode& node, std::vector<AnimatedTransform> prefix);
+    uint32_t EnsureBlasForMesh(uint32_t mesh_id,
+                               std::unordered_map<uint32_t, uint32_t>& mesh_to_blas);
+    void BuildLegacyMeshBvhAndLights();
 
     std::optional<SceneNode> graph_root_;
     std::vector<Sphere> spheres_;
+    std::vector<AnimatedSphere> animated_spheres_;
     std::vector<Material> materials_;
     std::vector<ImageTexture> textures_;
     std::vector<Mesh> meshes_;
     std::vector<Triangle> triangles_;
+    std::vector<Triangle> light_triangles_;
+    std::vector<Sphere> light_spheres_;
     std::vector<AreaLight> lights_;
     std::vector<HomogeneousMedium> homogeneous_media_;
     std::vector<GridMedium> grid_media_;
     std::vector<NanoVDBMedium> nanovdb_media_;
+    std::vector<BLAS> blases_;
+    std::vector<Instance> instances_;
+    TLAS tlas_;
     BVH bvh_;
-    float inv_light_count_;
+    float inv_light_count_ = 0.0f;
+    float shutter_open_ = 0.0f;
+    float shutter_close_ = 0.0f;
     uint16_t global_medium_id_ = 0;  // 0 represents Vacuum
 };
 

--- a/skewer/src/session/render_session.cc
+++ b/skewer/src/session/render_session.cc
@@ -77,6 +77,8 @@ void RenderSession::RenderScene(const std::string& scene_file, int thread_overri
     cam_vfov_ = config.vfov;
     cam_aperture_ = config.aperture_radius;
     cam_focus_dist_ = config.focus_distance;
+    cam_shutter_open_ = config.shutter_open;
+    cam_shutter_close_ = config.shutter_close;
 
     const bool multi_layer = config.layer_paths.size() > 1;
 
@@ -89,6 +91,7 @@ void RenderSession::RenderScene(const std::string& scene_file, int thread_overri
         auto layer_scene = std::make_unique<Scene>();
         LoadContextIntoScene(config.context_paths, *layer_scene);
         LayerConfig lcfg = LoadLayerFile(layer_path, *layer_scene);
+        layer_scene->SetShutter(cam_shutter_open_, cam_shutter_close_);
         layer_scene->Build();
 
         auto& opts = lcfg.render_options;
@@ -109,7 +112,8 @@ void RenderSession::RenderScene(const std::string& scene_file, int thread_overri
         float aspect = static_cast<float>(opts.image_config.width) /
                        static_cast<float>(opts.image_config.height);
         auto cam = std::make_unique<Camera>(cam_look_from_, cam_look_at_, cam_vup_, cam_vfov_,
-                                            aspect, cam_aperture_, cam_focus_dist_);
+                                            aspect, cam_aperture_, cam_focus_dist_,
+                                            cam_shutter_open_, cam_shutter_close_);
         ic.cam_w = -cam->GetW();
 
         auto film = std::make_unique<Film>(opts.image_config.width, opts.image_config.height);
@@ -151,6 +155,8 @@ void RenderSession::LoadSceneFromFile(const std::string& scene_file, int thread_
     }
     LayerConfig lcfg = LoadLayerFile(config.layer_paths[0], *scene_);
 
+    scene_->SetShutter(config.shutter_open, config.shutter_close);
+
     // 3. Build BVH acceleration structure
     scene_->Build();
 
@@ -170,12 +176,15 @@ void RenderSession::LoadSceneFromFile(const std::string& scene_file, int thread_
     cam_vfov_ = config.vfov;
     cam_aperture_ = config.aperture_radius;
     cam_focus_dist_ = config.focus_distance;
+    cam_shutter_open_ = config.shutter_open;
+    cam_shutter_close_ = config.shutter_close;
 
     // 6. Create camera (aspect ratio derived from image dimensions)
     float aspect = static_cast<float>(options_.image_config.width) /
                    static_cast<float>(options_.image_config.height);
     camera_ = std::make_unique<Camera>(cam_look_from_, cam_look_at_, cam_vup_, cam_vfov_, aspect,
-                                       cam_aperture_, cam_focus_dist_);
+                                       cam_aperture_, cam_focus_dist_, cam_shutter_open_,
+                                       cam_shutter_close_);
 
     // 7. Create film and integrator
     film_ = std::make_unique<Film>(options_.image_config.width, options_.image_config.height);
@@ -200,7 +209,8 @@ void RenderSession::RebuildFilm() {
     float aspect = static_cast<float>(options_.image_config.width) /
                    static_cast<float>(options_.image_config.height);
     camera_ = std::make_unique<Camera>(cam_look_from_, cam_look_at_, cam_vup_, cam_vfov_, aspect,
-                                       cam_aperture_, cam_focus_dist_);
+                                       cam_aperture_, cam_focus_dist_, cam_shutter_open_,
+                                       cam_shutter_close_);
     options_.integrator_config.cam_w = -camera_->GetW();
 
     film_ = std::make_unique<Film>(options_.image_config.width, options_.image_config.height);

--- a/skewer/src/session/render_session.h
+++ b/skewer/src/session/render_session.h
@@ -63,6 +63,8 @@ class RenderSession {
     float cam_vfov_ = 90.0f;
     float cam_aperture_ = 0.0f;
     float cam_focus_dist_ = 1.0f;
+    float cam_shutter_open_ = 0.0f;
+    float cam_shutter_close_ = 0.0f;
 };
 
 }  // namespace skwr

--- a/skewer/tests/CMakeLists.txt
+++ b/skewer/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SKEWER_SCENE_TEST_SOURCES
     ../src/scene/interp_curve.cc
     ../src/scene/animation.cc
     ../src/accelerators/bvh.cc
+    ../src/accelerators/tlas.cc
     ../src/scene/light.cc
     ../src/io/graph_from_json.cc
     ../src/io/scene_loader.cc
@@ -40,6 +41,8 @@ add_executable(unit_tests
     unit/test_interp_curve.cc
     unit/test_animation.cc
     unit/test_scene_graph.cc
+    unit/test_tlas.cc
+    unit/test_motion_blur.cc
     ${TEST_SOURCES}
     ${SKEWER_SCENE_TEST_SOURCES}
 )

--- a/skewer/tests/unit/test_motion_blur.cc
+++ b/skewer/tests/unit/test_motion_blur.cc
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include "core/math/transform.h"
+#include "core/math/vec3.h"
+#include "core/ray.h"
+#include "core/sampling/rng.h"
+#include "geometry/animated_sphere.h"
+#include "media/mediums.h"
+#include "scene/animation.h"
+#include "scene/camera.h"
+
+namespace skwr {
+
+TEST(MotionBlur, CameraShutterSamplesRayTimeInRange) {
+    Vec3 from(0.0f, 0.0f, 0.0f);
+    Vec3 at(0.0f, 0.0f, -1.0f);
+    Vec3 up(0.0f, 1.0f, 0.0f);
+    Camera cam(from, at, up, 60.0f, 1.0f, 0.0f, 1.0f, 0.1f, 0.9f);
+    RNG rng(0, 42);
+    for (int i = 0; i < 32; ++i) {
+        Ray r = cam.GetRay(0.5f, 0.5f, rng);
+        EXPECT_GE(r.time(), 0.1f);
+        EXPECT_LE(r.time(), 0.9f);
+    }
+}
+
+TEST(MotionBlur, CameraZeroShutterAllRaysSameTime) {
+    Vec3 from(0.0f, 0.0f, 0.0f);
+    Vec3 at(0.0f, 0.0f, -1.0f);
+    Vec3 up(0.0f, 1.0f, 0.0f);
+    Camera cam(from, at, up, 60.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f);
+    RNG rng(0, 7);
+    for (int i = 0; i < 8; ++i) {
+        Ray r = cam.GetRay(0.1f, 0.2f, rng);
+        EXPECT_NEAR(r.time(), 0.0f, 1e-6f);
+    }
+}
+
+TEST(MotionBlur, TRSInverseApplyRoundTripPoint) {
+    TRS trs =
+        TRSFromEuler(Vec3(1.0f, 2.0f, 3.0f), Vec3(10.0f, 20.0f, 30.0f), Vec3(2.0f, 2.0f, 2.0f));
+    Vec3 p(0.5f, -0.25f, 1.0f);
+    Vec3 q = TRSApplyPoint(trs, p);
+    Vec3 back = TRSInverseApplyPoint(trs, q);
+    EXPECT_NEAR(back.x(), p.x(), 1e-4f);
+    EXPECT_NEAR(back.y(), p.y(), 1e-4f);
+    EXPECT_NEAR(back.z(), p.z(), 1e-4f);
+}
+
+TEST(MotionBlur, TRSInverseApplyVectorRoundTrip) {
+    TRS trs = TRSFromEuler(Vec3(0.0f, 0.0f, 0.0f), Vec3(0.0f, 45.0f, 0.0f), Vec3(3.0f, 3.0f, 3.0f));
+    Vec3 v = Normalize(Vec3(1.0f, 1.0f, 0.0f));
+    Vec3 w = TRSApplyVector(trs, v);
+    Vec3 back = TRSInverseApplyVector(trs, w);
+    EXPECT_NEAR(back.x(), v.x(), 1e-4f);
+    EXPECT_NEAR(back.y(), v.y(), 1e-4f);
+    EXPECT_NEAR(back.z(), v.z(), 1e-4f);
+}
+
+TEST(MotionBlur, AnimatedSphereEvaluatesAtTime) {
+    SphereData sd{};
+    sd.center = Vec3(0.0f, 0.0f, 0.0f);
+    sd.radius = 1.0f;
+    sd.material_id = kNullMaterialId;
+    sd.interior_medium = kVacuumMediumId;
+    sd.exterior_medium = kVacuumMediumId;
+
+    AnimatedTransform anim;
+    Keyframe k0;
+    k0.time = 0.0f;
+    k0.transform.translation = Vec3(0.0f, 0.0f, 0.0f);
+    Keyframe k1;
+    k1.time = 1.0f;
+    k1.transform.translation = Vec3(4.0f, 0.0f, 0.0f);
+    anim.keyframes = {k0, k1};
+
+    AnimatedSphere as;
+    as.local_data = sd;
+    as.transform_chain = {anim};
+
+    Sphere s_mid = as.EvaluateAt(0.5f);
+    EXPECT_NEAR(s_mid.center.x(), 2.0f, 1e-4f);
+}
+
+}  // namespace skwr

--- a/skewer/tests/unit/test_scene_graph.cc
+++ b/skewer/tests/unit/test_scene_graph.cc
@@ -8,10 +8,13 @@
 #include <stdexcept>
 
 #include "core/cpu_config.h"
+#include "core/math/constants.h"
 #include "core/math/quat.h"
 #include "core/math/transform.h"
 #include "core/math/vec3.h"
+#include "core/ray.h"
 #include "core/spectral/spectral_utils.h"
+#include "core/transport/surface_interaction.h"
 #include "geometry/mesh.h"
 #include "io/graph_from_json.h"
 #include "io/scene_loader.h"
@@ -105,7 +108,10 @@ TEST(SceneGraph, LoadLayerQuadFromFile) {
     LoadLayerFile(p.string(), scene);
     EXPECT_EQ(scene.MeshCount(), 1u);
     scene.Build();
-    EXPECT_FALSE(scene.Triangles().empty());
+    Ray r(Vec3(0.5f, 0.5f, 1.0f), Vec3(0.0f, 0.0f, -1.0f), 0.0f);
+    SurfaceInteraction si{};
+    EXPECT_TRUE(
+        scene.Intersect(r, RenderConstants::kRayOffsetEpsilon, MathConstants::kFloatInfinity, &si));
     std::filesystem::remove(p);
 }
 
@@ -142,10 +148,13 @@ TEST(SceneGraph, NestedTranslateFlatten) {
     scene.MergeGraphRoots({std::move(parent)});
     scene.Build();
 
-    ASSERT_FALSE(scene.Triangles().empty());
-    const Triangle& tri = scene.Triangles()[0];
-    EXPECT_NEAR(tri.p0.x(), 5.0f, 1e-4f);
-    EXPECT_NEAR(tri.p0.y(), 3.0f, 1e-4f);
+    Ray r(Vec3(5.33f, 3.33f, 1.0f), Vec3(0.0f, 0.0f, -1.0f), 0.0f);
+    SurfaceInteraction si{};
+    ASSERT_TRUE(
+        scene.Intersect(r, RenderConstants::kRayOffsetEpsilon, MathConstants::kFloatInfinity, &si));
+    EXPECT_NEAR(si.point.x(), 5.33f, 0.02f);
+    EXPECT_NEAR(si.point.y(), 3.33f, 0.02f);
+    EXPECT_NEAR(si.point.z(), 0.0f, 1e-3f);
 }
 
 TEST(SceneGraph, SphereUniformScaleWorld) {
@@ -215,7 +224,7 @@ TEST(SceneGraph, SphereNonUniformScaleThrows) {
     EXPECT_THROW(scene.Build(), std::runtime_error);
 }
 
-TEST(SceneGraph, BuildTwiceDoesNotDoubleTransform) {
+TEST(SceneGraph, BuildSingleTransformHitPosition) {
     Material mat{};
     mat.type = MaterialType::Lambertian;
     mat.albedo = {{0.8f, 0.8f, 0.8f}, 1.0f};
@@ -246,11 +255,12 @@ TEST(SceneGraph, BuildTwiceDoesNotDoubleTransform) {
 
     scene.MergeGraphRoots({std::move(parent)});
     scene.Build();
-    float x1 = scene.Triangles()[0].p0.x();
-    scene.Build();
-    float x2 = scene.Triangles()[0].p0.x();
-    EXPECT_NEAR(x1, x2, 1e-5f);
-    EXPECT_NEAR(x1, 1.0f, 1e-4f);
+    Ray r(Vec3(1.33f, 0.33f, 1.0f), Vec3(0.0f, 0.0f, -1.0f), 0.0f);
+    SurfaceInteraction si{};
+    ASSERT_TRUE(
+        scene.Intersect(r, RenderConstants::kRayOffsetEpsilon, MathConstants::kFloatInfinity, &si));
+    EXPECT_NEAR(si.point.x(), 1.33f, 0.02f);
+    EXPECT_NEAR(si.point.y(), 0.33f, 0.02f);
 }
 
 }  // namespace skwr

--- a/skewer/tests/unit/test_tlas.cc
+++ b/skewer/tests/unit/test_tlas.cc
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include "accelerators/blas.h"
+#include "accelerators/instance.h"
+#include "accelerators/tlas.h"
+#include "core/cpu_config.h"
+#include "core/math/transform.h"
+#include "core/math/vec3.h"
+#include "core/ray.h"
+#include "core/transport/surface_interaction.h"
+#include "geometry/triangle.h"
+#include "scene/animation.h"
+
+namespace skwr {
+
+TEST(TLAS, SingleStaticInstanceMatchesDirectBvh) {
+    Triangle tri{};
+    tri.p0 = Vec3(0.0f, 0.0f, 0.0f);
+    tri.e1 = Vec3(1.0f, 0.0f, 0.0f);
+    tri.e2 = Vec3(0.0f, 1.0f, 0.0f);
+    tri.n0 = tri.n1 = tri.n2 = Vec3(0.0f, 0.0f, 1.0f);
+    tri.uv0 = tri.uv1 = tri.uv2 = Vec3(0.0f, 0.0f, 0.0f);
+    tri.material_id = kNullMaterialId;
+
+    std::vector<Triangle> tris{tri};
+    BLAS blas;
+    blas.triangles = tris;
+    blas.local_bounds = BoundBox(Vec3(0, 0, 0), Vec3(1, 1, 0));
+    blas.local_bounds.PadToMinimums();
+    blas.bvh.Build(blas.triangles);
+    std::vector<BLAS> blases;
+    blases.push_back(std::move(blas));
+
+    AnimatedTransform id{};
+    Instance inst;
+    inst.blas_id = 0;
+    inst.transform_chain = {id};
+    inst.is_static = true;
+    inst.static_world_from_local = EvaluateTransformChain(inst.transform_chain, 0.0f);
+    inst.world_bounds = TransformBounds(inst.static_world_from_local, blases[0].local_bounds);
+    inst.tri_light_indices.assign(blases[0].triangles.size(), -1);
+
+    std::vector<Instance> instances{inst};
+    TLAS tlas;
+    tlas.Build(instances);
+
+    Ray r(Vec3(0.25f, 0.25f, 1.0f), Vec3(0.0f, 0.0f, -1.0f), 0.0f);
+    SurfaceInteraction si_tlas{};
+    ASSERT_TRUE(tlas.Intersect(r, 1e-4f, 1e10f, &si_tlas, blases, instances));
+
+    SurfaceInteraction si_bvh{};
+    ASSERT_TRUE(blases[0].bvh.Intersect(r, 1e-4f, 1e10f, &si_bvh, blases[0].triangles));
+
+    EXPECT_NEAR(si_tlas.t, si_bvh.t, 1e-4f);
+    EXPECT_NEAR(si_tlas.point.x(), si_bvh.point.x(), 1e-4f);
+    EXPECT_NEAR(si_tlas.point.y(), si_bvh.point.y(), 1e-4f);
+}
+
+TEST(TLAS, AnimatedInstanceMovesWithRayTime) {
+    Triangle tri{};
+    tri.p0 = Vec3(0.0f, 0.0f, 0.0f);
+    tri.e1 = Vec3(0.2f, 0.0f, 0.0f);
+    tri.e2 = Vec3(0.0f, 0.2f, 0.0f);
+    tri.n0 = tri.n1 = tri.n2 = Vec3(0.0f, 0.0f, 1.0f);
+    tri.uv0 = tri.uv1 = tri.uv2 = Vec3(0.0f, 0.0f, 0.0f);
+    tri.material_id = kNullMaterialId;
+
+    BLAS blas;
+    blas.triangles = {tri};
+    blas.local_bounds = BoundBox(Vec3(0, 0, 0), Vec3(0.2f, 0.2f, 0.0f));
+    blas.local_bounds.PadToMinimums();
+    blas.bvh.Build(blas.triangles);
+    std::vector<BLAS> blases;
+    blases.push_back(std::move(blas));
+
+    AnimatedTransform anim;
+    Keyframe k0;
+    k0.time = 0.0f;
+    k0.transform.translation = Vec3(0.0f, 0.0f, 0.0f);
+    Keyframe k1;
+    k1.time = 1.0f;
+    k1.transform.translation = Vec3(2.0f, 0.0f, 0.0f);
+    anim.keyframes = {k0, k1};
+
+    Instance inst;
+    inst.blas_id = 0;
+    inst.transform_chain = {anim};
+    inst.is_static = false;
+    inst.static_world_from_local = {};
+    BoundBox lb = blases[0].local_bounds;
+    TRS a = EvaluateTransformChain(inst.transform_chain, 0.0f);
+    TRS b = EvaluateTransformChain(inst.transform_chain, 1.0f);
+    inst.world_bounds = Union(TransformBounds(a, lb), TransformBounds(b, lb));
+    inst.tri_light_indices.assign(blases[0].triangles.size(), -1);
+
+    std::vector<Instance> instances{inst};
+    TLAS tlas;
+    tlas.Build(instances);
+
+    Ray r0(Vec3(0.1f, 0.1f, 1.0f), Vec3(0.0f, 0.0f, -1.0f), 0.0f);
+    SurfaceInteraction si0{};
+    ASSERT_TRUE(tlas.Intersect(r0, 1e-4f, 1e10f, &si0, blases, instances));
+    EXPECT_NEAR(si0.point.x(), 0.1f, 0.02f);
+
+    Ray r1(Vec3(2.1f, 0.1f, 1.0f), Vec3(0.0f, 0.0f, -1.0f), 1.0f);
+    SurfaceInteraction si1{};
+    ASSERT_TRUE(tlas.Intersect(r1, 1e-4f, 1e10f, &si1, blases, instances));
+    EXPECT_NEAR(si1.point.x(), 2.1f, 0.02f);
+}
+
+}  // namespace skwr


### PR DESCRIPTION
This PR modifies the renderer to add temporal sampling for objects with keyframes defined along with pose interpolation to achieve motion blur.

Sample images:

![layer Large](https://github.com/user-attachments/assets/2b06ac70-7ce6-4c01-86d7-a3e829b78191)

![layer Large](https://github.com/user-attachments/assets/ffeaa13c-7ca0-46af-9ccd-c7482b1f6a7e)

Note: Merge #166 first

Closes #162 