### PR TITLE
Fix curve destination conventions across scene editor and renderer

### DIFF
--- a/apps/scene-previewer/src/components/PropertiesPanel.tsx
+++ b/apps/scene-previewer/src/components/PropertiesPanel.tsx
@@ -199,7 +199,7 @@ function CommonTransformBlock({
 					})}
 				</div>
 
-				{selKf && idx < sortedKfs.length - 1 && (
+				{selKf && idx > 0 && (
 					<div className="kv-row kf-curve-row">
 						<span className="kv-key">curve</span>
 						<select
@@ -219,7 +219,7 @@ function CommonTransformBlock({
 					</div>
 				)}
 
-				{selKf && curveToPreset(selKf.curve) === "custom" && (
+				{selKf && idx > 0 && curveToPreset(selKf.curve) === "custom" && (
 					<div className="kf-bezier-grid">
 						{(["p1x", "p1y", "p2x", "p2y"] as const).map((label, i) => (
 							<NumberField

--- a/apps/scene-previewer/src/services/transform.ts
+++ b/apps/scene-previewer/src/services/transform.ts
@@ -114,7 +114,7 @@ function solveBezierParameter(
 	return sampleBezierY(t, p1y, p2y);
 }
 
-/** Easing alpha in [0,1] for segment progress u in [0,1], using k0's curve (k0 → k1). */
+/** Easing alpha in [0,1] for segment progress u in [0,1], using k1's curve (k0 → k1). */
 export function evaluateBezierEasing(
 	curve: InterpCurve | undefined,
 	u: number,
@@ -220,7 +220,7 @@ export function evaluateTransformAt(
 
 	let localU = (time - k0.time) / dt;
 	localU = Math.min(1, Math.max(0, localU));
-	const alpha = evaluateBezierEasing(k0.curve, localU);
+	const alpha = evaluateBezierEasing(k1.curve, localU);
 	return interpolateResolved(k0, k1, alpha);
 }
 

--- a/skewer/src/scene/animation.cc
+++ b/skewer/src/scene/animation.cc
@@ -53,7 +53,7 @@ TRS AnimatedTransform::Evaluate(float t) const {
     }
     float local_u = (t - k0.time) / dt;
     local_u = std::clamp(local_u, 0.0f, 1.0f);
-    float alpha = EvalCurveOrLinear(k0.curve, local_u);
+    float alpha = EvalCurveOrLinear(k1.curve, local_u);
 
     TRS out{};
     out.translation = LerpVec3(k0.transform.translation, k1.transform.translation, alpha);

--- a/skewer/src/scene/animation.h
+++ b/skewer/src/scene/animation.h
@@ -13,7 +13,8 @@ class InterpolationCurve;
 struct Keyframe {
     float time = 0.0f;
     TRS transform;
-    // Easing from this keyframe toward the next; ignored on last keyframe.
+    // Easing for the segment arriving at this keyframe from the previous one;
+    // ignored on the first keyframe.
     std::shared_ptr<const InterpolationCurve> curve;
 };
 

--- a/skewer/tests/unit/test_animation.cc
+++ b/skewer/tests/unit/test_animation.cc
@@ -78,7 +78,7 @@ TEST(Animation, EasedSegmentUsesCurveNotHalfway) {
 
     AnimatedTransform ease_anim = linear_anim;
     static BezierCurve kEase = BezierCurve::EaseIn();
-    ease_anim.keyframes[0].curve =
+    ease_anim.keyframes[1].curve =
         std::shared_ptr<const InterpolationCurve>(&kEase, [](const InterpolationCurve*) {});
 
     float lin_z = linear_anim.Evaluate(0.5f).translation.z();


### PR DESCRIPTION
## Summary
- Align curve destination handling between the scene previewer, scene loader/serializer, and render core
- Update animation, transform, and scene graph logic to use the corrected convention end to end
- Refresh preview templates and UI controls to match the new behavior
- Add and update unit coverage for animation, motion blur, scene graph, and TLAS behavior

## Testing
- Added/updated unit tests for animation, motion blur, scene graph, and TLAS
- Validated the scene previewer build path and related workflow changes at a high level