### PR TITLE
Added support for x86_64 chips by providing -isystem compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64")
     add_compile_options(-isystem /usr/local/include)
     link_directories(/usr/local/lib)
 endif()
@@ -16,7 +16,6 @@ endif()
 
 include(CTest)
 
-find_package(OpenSSL REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(Protobuf REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,18 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    add_compile_options(-isystem /usr/local/include)
+    link_directories(/usr/local/lib)
+endif()
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror -std=c++20)
 endif()
 
 include(CTest)
 
+find_package(OpenSSL REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(Protobuf REQUIRED)
 


### PR DESCRIPTION
Quick PR to support older library format. Before Apple chips, homebrew installed everything under **/usr/local/include** which is no longer seen as a library path on newer OS's. Given the strict requirements with -Werror, this minor change simply tells CMake how to treat include on x86_64 devices. 