### PR TITLE
[bugfix] Deep Merger Overflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ skewer/external/srgb_spec_data.h filter=lfs diff=lfs merge=lfs -text
 tests/integration/fixtures/golden_images/*.exr filter=lfs diff=lfs merge=lfs -text
 tests/integration/fixtures/golden_images/*.png filter=lfs diff=lfs merge=lfs -text
 tests/integration/fixtures/golden_scenes/**/*.nvdb filter=lfs diff=lfs merge=lfs -text
+loom/tests/assets/*.exr filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Fetch required LFS header
         run: |
           git lfs fetch --include="skewer/external/srgb_spec_data.h"
+          git lfs fetch --include="loom/tests/assets/layer_fog.exr"
+          git lfs fetch --include="loom/testz/assets/layer_objects.exr"
           git lfs checkout
 
       - name: Restore ccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           git lfs fetch --include="skewer/external/srgb_spec_data.h"
           git lfs fetch --include="loom/tests/assets/layer_fog.exr"
-          git lfs fetch --include="loom/testz/assets/layer_objects.exr"
+          git lfs fetch --include="loom/tests/assets/layer_objects.exr"
           git lfs checkout
 
       - name: Restore ccache

--- a/loom/src/deep_compositor.cc
+++ b/loom/src/deep_compositor.cc
@@ -130,15 +130,17 @@ void MergerWorker(int start_row, int end_row, PipelineContext& ctx) {
         int slot = merge_y % ctx.window_size;
         DeepRow& outputRow = ctx.merged_buffer[slot];
 
-        int maxSamplesForPixel = 0; // tracks the maximum number of samples for any pixel across all files
+        int maxSamplesForPixel =
+            0;  // tracks the maximum number of samples for any pixel across all files
         for (int x = 0; x < ctx.width; ++x) {
-            int perPixelTotal = 0; // tracks samples for THIS pixel across all files
+            int perPixelTotal = 0;  // tracks samples for THIS pixel across all files
 
             // Go through each file and sum the samples for this pixel
             for (int i = 0; i < ctx.num_files; ++i) {
                 perPixelTotal += ctx.input_buffer[i][slot].GetSampleCount(x);
             }
-            if (perPixelTotal > maxSamplesForPixel) maxSamplesForPixel = perPixelTotal; // update maxSamplesForPixel if necessary
+            if (perPixelTotal > maxSamplesForPixel)
+                maxSamplesForPixel = perPixelTotal;  // update maxSamplesForPixel if necessary
         }
 
         // Safety buffer for volumetric splitting

--- a/loom/src/deep_compositor.cc
+++ b/loom/src/deep_compositor.cc
@@ -130,21 +130,14 @@ void MergerWorker(int start_row, int end_row, PipelineContext& ctx) {
         int slot = merge_y % ctx.window_size;
         DeepRow& outputRow = ctx.merged_buffer[slot];
 
-        int maxSamplesForPixel =
+        int total_input_samples =
             0;  // tracks the maximum number of samples for any pixel across all files
-        for (int x = 0; x < ctx.width; ++x) {
-            int perPixelTotal = 0;  // tracks samples for THIS pixel across all files
-
-            // Go through each file and sum the samples for this pixel
-            for (int i = 0; i < ctx.num_files; ++i) {
-                perPixelTotal += ctx.input_buffer[i][slot].GetSampleCount(x);
-            }
-            if (perPixelTotal > maxSamplesForPixel)
-                maxSamplesForPixel = perPixelTotal;  // update maxSamplesForPixel if necessary
+        for (int i = 0; i < ctx.num_files; ++i) {
+            total_input_samples += ctx.input_buffer[i][slot].total_samples_in_row;
         }
 
         // Safety buffer for volumetric splitting
-        outputRow.Allocate(ctx.width, maxSamplesForPixel * 2);
+        outputRow.Allocate(ctx.width, total_input_samples * 2);
 
         // One running pointer per input file to avoid O(x) prefix-sum in GetPixelData
         std::vector<const float*> runningPtrs(ctx.num_files);

--- a/loom/src/deep_compositor.cc
+++ b/loom/src/deep_compositor.cc
@@ -130,9 +130,15 @@ void MergerWorker(int start_row, int end_row, PipelineContext& ctx) {
         int slot = merge_y % ctx.window_size;
         DeepRow& outputRow = ctx.merged_buffer[slot];
 
-        int maxSamplesForPixel = 0;
-        for (int i = 0; i < ctx.num_files; ++i) {
-            maxSamplesForPixel += ctx.input_buffer[i][slot].total_samples_in_row;
+        int maxSamplesForPixel = 0; // tracks the maximum number of samples for any pixel across all files
+        for (int x = 0; x < ctx.width; ++x) {
+            int perPixelTotal = 0; // tracks samples for THIS pixel across all files
+
+            // Go through each file and sum the samples for this pixel
+            for (int i = 0; i < ctx.num_files; ++i) {
+                perPixelTotal += ctx.input_buffer[i][slot].GetSampleCount(x);
+            }
+            if (perPixelTotal > maxSamplesForPixel) maxSamplesForPixel = perPixelTotal; // update maxSamplesForPixel if necessary
         }
 
         // Safety buffer for volumetric splitting

--- a/loom/src/deep_merger.cc
+++ b/loom/src/deep_merger.cc
@@ -78,7 +78,7 @@ std::pair<RawSample, RawSample> SplitSample(const RawSample& s, float zSplit) {
 void SortAndMergePixelsDirect(int x, const std::vector<const float*>& pixelDataPtrs,
                               const std::vector<unsigned int>& pixelSampleCounts,
                               DeepRow& outputRow, float merge_threshold) {
-    // 1. Collect all raw samples into a temporary flat vector
+    // Collect all raw samples into a temporary flat vector
     // We reuse this vector across pixels to avoid re-allocation
     static thread_local std::vector<RawSample> staging;
     staging.clear();
@@ -102,7 +102,7 @@ void SortAndMergePixelsDirect(int x, const std::vector<const float*>& pixelDataP
         return;
     }
 
-    // 2. [Your Volumetric Splitting/Sorting Logic Here]
+    // Volumetric splitting and sorting
     std::sort(staging.begin(), staging.end());
 
     if (!staging.empty()) {
@@ -127,10 +127,8 @@ void SortAndMergePixelsDirect(int x, const std::vector<const float*>& pixelDataP
         staging.swap(merged);
     }
 
-    // 3. Write results back to the outputRow
-
-    float* outPtr = outputRow.GetPixelData(
-        x);  //! CONSIDER RESIZING THE OUTPUT ROW HERE IF STAGING SIZE EXCEEDS CURRENT CAPACITY
+    // Write results back to the outputRow
+    float* outPtr = outputRow.GetPixelData(x);
 
     // Write the sorted samples back
     for (size_t s = 0; s < staging.size(); ++s) {
@@ -140,7 +138,7 @@ void SortAndMergePixelsDirect(int x, const std::vector<const float*>& pixelDataP
         dest[2] = staging[s].b;
         dest[3] = staging[s].a;
         dest[4] = staging[s].z;
-        dest[5] = staging[s].z_back;  // If you have ZBack, write it here
+        dest[5] = staging[s].z_back;  // If we have ZBack, write it here
     }
 
     // Update the output sample count for this pixel
@@ -152,7 +150,7 @@ void SortAndMergePixelsDirect(int x, const std::vector<const float*>& pixelDataP
 void SortAndMergePixelsWithSplit(int x, const std::vector<const float*>& pixelDataPtrs,
                                  const std::vector<unsigned int>& pixelSampleCounts,
                                  DeepRow& outputRow, float merge_threshold) {
-    // 1. Collect all raw samples into a temporary flat vector
+    // Collect all raw samples into a temporary flat vector
     static thread_local std::vector<RawSample> staging;
     staging.clear();
 
@@ -174,7 +172,7 @@ void SortAndMergePixelsWithSplit(int x, const std::vector<const float*>& pixelDa
 
     float epsilon = merge_threshold;
 
-    // 2. Gather split points: every unique depth and depth_back
+    // Gather split points: every unique depth and depth_back
     std::set<float> splitPointSet;
     for (const auto& s : staging) {
         splitPointSet.insert(s.z);
@@ -183,7 +181,7 @@ void SortAndMergePixelsWithSplit(int x, const std::vector<const float*>& pixelDa
     std::vector<float> splitPoints(splitPointSet.begin(), splitPointSet.end());
     // splitPoints is naturally sorted by std::set
 
-    // 3. Split each volumetric sample at every split point inside its range
+    // Split each volumetric sample at every split point inside its range
     std::vector<RawSample> fragments;
     fragments.reserve(staging.size() * 2);
 
@@ -220,10 +218,10 @@ void SortAndMergePixelsWithSplit(int x, const std::vector<const float*>& pixelDa
         fragments.push_back(remainder);
     }
 
-    // 4. Sort fragments by (z, z_back)
+    // Sort fragments by (z, z_back)
     std::sort(fragments.begin(), fragments.end());
 
-    // 5. Blend consecutive fragments with matching intervals
+    // Blend consecutive fragments with matching intervals
     std::vector<RawSample> blended;
     blended.reserve(fragments.size());
 
@@ -241,7 +239,7 @@ void SortAndMergePixelsWithSplit(int x, const std::vector<const float*>& pixelDa
         blended.push_back(current);
     }
 
-    // 6. Write results back to the outputRow
+    // Write results back to the outputRow
     float* outPtr = outputRow.GetPixelData(x);
     for (size_t s = 0; s < blended.size(); ++s) {
         float* dest = outPtr + (s * 6);

--- a/loom/src/deep_merger.cc
+++ b/loom/src/deep_merger.cc
@@ -239,6 +239,12 @@ void SortAndMergePixelsWithSplit(int x, const std::vector<const float*>& pixelDa
         blended.push_back(current);
     }
 
+    // Ensure we have enough capacity in the contiguous buffer for the new fragments
+    outputRow.EnsureCapacity(outputRow.total_samples_in_row + blended.size());
+
+    // Write results back to the outputRow
+    outputRow.sample_offsets[x] = outputRow.total_samples_in_row;
+
     // Write results back to the outputRow
     float* outPtr = outputRow.GetPixelData(x);
     for (size_t s = 0; s < blended.size(); ++s) {
@@ -253,6 +259,5 @@ void SortAndMergePixelsWithSplit(int x, const std::vector<const float*>& pixelDa
 
     // Update the output sample count for this pixel
     outputRow.sample_counts[x] = static_cast<unsigned int>(blended.size());
-    if (x + 1 < outputRow.width)
-        outputRow.sample_offsets[x + 1] = outputRow.sample_offsets[x] + blended.size();
+    outputRow.total_samples_in_row += blended.size();
 }

--- a/loom/src/deep_options.h
+++ b/loom/src/deep_options.h
@@ -2,7 +2,6 @@
 #define LOOM_SRC_DEEP_OPTIONS_H
 
 #include <cstring>
-#include <iostream>
 #include <string>
 #include <vector>
 

--- a/loom/src/deep_row.h
+++ b/loom/src/deep_row.h
@@ -53,7 +53,7 @@ struct DeepRow {
 
         size_t total_capacity = static_cast<size_t>(width) * max_samples_per_pixel;
 
-        size_t required = total_capacity * 6; // for each channel
+        size_t required = total_capacity * 6;  // for each channel
         // make_unique handles 'new float[]' and ensures cleanup
         all_samples = std::make_unique<float[]>(required);
         current_capacity = required;

--- a/loom/src/deep_row.h
+++ b/loom/src/deep_row.h
@@ -46,13 +46,14 @@ struct DeepRow {
     }
 
     // Normal Allocate given a size
-    void Allocate(size_t width, int max_samples) {
+    void Allocate(size_t width, int max_samples_per_pixel) {
         this->width = width;
         sample_counts.assign(width, 0);
         sample_offsets.assign(width, 0);  // all zero; merger updates incrementally
-        total_samples_in_row = max_samples;
 
-        size_t required = static_cast<size_t>(max_samples) * 6;
+        size_t total_capacity = static_cast<size_t>(width) * max_samples_per_pixel;
+
+        size_t required = total_capacity * 6; // for each channel
         // make_unique handles 'new float[]' and ensures cleanup
         all_samples = std::make_unique<float[]>(required);
         current_capacity = required;

--- a/loom/src/deep_row.h
+++ b/loom/src/deep_row.h
@@ -11,8 +11,8 @@ struct DeepRow {
     int width = 0;
     std::vector<unsigned int> sample_counts;
     std::vector<size_t> sample_offsets;  // sample_offsets[x] = sum(sample_counts[0..x-1])
-    size_t total_samples_in_row = 0;
-    size_t current_capacity = 0;
+    size_t total_samples_in_row = 0; // Tracks actual used samples
+    size_t current_capacity = 0; // Tracks allocated capacity
 
     DeepRow() = default;
 
@@ -46,17 +46,14 @@ struct DeepRow {
     }
 
     // Normal Allocate given a size
-    void Allocate(size_t width, int max_samples_per_pixel) {
+    void Allocate(size_t width, int estimated_total_samples) {
         this->width = width;
         sample_counts.assign(width, 0);
-        sample_offsets.assign(width, 0);  // all zero; merger updates incrementally
+        sample_offsets.assign(width, 0);
 
-        size_t total_capacity = static_cast<size_t>(width) * max_samples_per_pixel;
-
-        size_t required = total_capacity * 6;  // for each channel
-        // make_unique handles 'new float[]' and ensures cleanup
-        all_samples = std::make_unique<float[]>(required);
-        current_capacity = required;
+        total_samples_in_row = 0; // Starts at 0, grows as we merge
+        current_capacity = static_cast<size_t>(estimated_total_samples) * 6;
+        all_samples = std::make_unique<float[]>(current_capacity);
     }
 
     // Allocate full block based on actual sample counts for the row
@@ -73,6 +70,23 @@ struct DeepRow {
         size_t required = total_samples_in_row * 6;
         all_samples = std::make_unique<float[]>(required);
         current_capacity = required;
+    }
+
+    void EnsureCapacity(size_t required_samples) {
+        size_t required_floats = required_samples * 6;
+        if (required_floats > current_capacity) {
+            // Grow by 1.5x to amortize allocation cost, plus a constant for safety
+            size_t new_capacity = required_floats + (current_capacity / 2) + 128;
+            auto new_buffer = std::make_unique<float[]>(new_capacity);
+
+            if (all_samples) {
+                // Fast copy of existing data to the new contiguous block
+                std::memcpy(new_buffer.get(), all_samples.get(), total_samples_in_row * 6 * sizeof(float));
+            }
+
+            all_samples = std::move(new_buffer);
+            current_capacity = new_capacity;
+        }
     }
 
     // Get pointer to the nth sample of pixel x
@@ -102,14 +116,6 @@ struct DeepRow {
     DeepRow& operator=(const DeepRow&) = delete;
 
     ~DeepRow() = default;
-
-  private:
-    void ensureCapacity(size_t required) {
-        if (required > current_capacity) {
-            all_samples = std::make_unique<float[]>(required);
-            current_capacity = required;
-        }
-    }
 };
 
 // Converts a row of deep data into a flattened RGBA image row

--- a/loom/src/deep_row.h
+++ b/loom/src/deep_row.h
@@ -12,8 +12,8 @@ struct DeepRow {
     int width = 0;
     std::vector<unsigned int> sample_counts;
     std::vector<size_t> sample_offsets;  // sample_offsets[x] = sum(sample_counts[0..x-1])
-    size_t total_samples_in_row = 0; // Tracks actual used samples
-    size_t current_capacity = 0; // Tracks allocated capacity
+    size_t total_samples_in_row = 0;     // Tracks actual used samples
+    size_t current_capacity = 0;         // Tracks allocated capacity
 
     DeepRow() = default;
 
@@ -52,7 +52,7 @@ struct DeepRow {
         sample_counts.assign(width, 0);
         sample_offsets.assign(width, 0);
 
-        total_samples_in_row = 0; // Starts at 0, grows as we merge
+        total_samples_in_row = 0;  // Starts at 0, grows as we merge
         current_capacity = static_cast<size_t>(estimated_total_samples) * 6;
         all_samples = std::make_unique<float[]>(current_capacity);
     }
@@ -82,7 +82,8 @@ struct DeepRow {
 
             if (all_samples) {
                 // Fast copy of existing data to the new contiguous block
-                std::memcpy(new_buffer.get(), all_samples.get(), total_samples_in_row * 6 * sizeof(float));
+                std::memcpy(new_buffer.get(), all_samples.get(),
+                            total_samples_in_row * 6 * sizeof(float));
             }
 
             all_samples = std::move(new_buffer);

--- a/loom/src/deep_row.h
+++ b/loom/src/deep_row.h
@@ -1,6 +1,7 @@
 #ifndef LOOM_SRC_DEEP_ROW_H
 #define LOOM_SRC_DEEP_ROW_H
 
+#include <cstring>
 #include <memory>
 #include <vector>
 

--- a/loom/src/main.cc
+++ b/loom/src/main.cc
@@ -4,9 +4,9 @@
 
 #include <cstring>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 #include "deep_compositor.h"
 #include "deep_info.h"

--- a/loom/src/main.cc
+++ b/loom/src/main.cc
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 
-#include "composite_pipeline.h"
 #include "deep_compositor.h"
 #include "deep_info.h"
 #include "deep_options.h"

--- a/loom/src/main.cc
+++ b/loom/src/main.cc
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <sstream>
 
 #include "deep_compositor.h"
 #include "deep_info.h"

--- a/loom/src/main.cc
+++ b/loom/src/main.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "composite_pipeline.h"
 #include "deep_compositor.h"
 #include "deep_info.h"
 #include "deep_options.h"
@@ -170,51 +171,10 @@ int main(int argc, char* argv[]) {
     Timer loadTimer;
 
     std::vector<std::unique_ptr<DeepInfo>> imagesInfo;
-
-    for (size_t i = 0; i < opts.input_files.size(); ++i) {
-        const std::string& filename = opts.input_files[i];
-
-        LogVerbose("  [" + std::to_string(i + 1) + "/" + std::to_string(opts.input_files.size()) +
-                   "] " + filename);
-        printf("Preloading [%zu/%zu]: %s\n", i + 1, opts.input_files.size(), filename.c_str());
-        try {
-            // Check if it's a deep EXR
-            if (!exrio::isDeepEXR(filename)) {
-                LogError("File is not a deep EXR: " + filename);
-                return 1;
-            }
-
-            auto img = std::make_unique<DeepInfo>(filename);
-            // Log statistics
-            std::string stats =
-                "    " + std::to_string(img->width()) + "x" + std::to_string(img->height());
-            LogVerbose(stats);
-            if (!imagesInfo.empty()) {
-                if (img->width() != imagesInfo[0]->width() ||
-                    img->height() != imagesInfo[0]->height()) {
-                    LogError("Image dimensions mismatch: " + filename);
-                    LogError("  Expected: " + std::to_string(imagesInfo[0]->width()) + "x" +
-                             std::to_string(imagesInfo[0]->height()));
-                    LogError("  Got: " + std::to_string(img->width()) + "x" +
-                             std::to_string(img->height()));
-                    return 1;
-                }
-            }
-
-            imagesInfo.push_back(std::move(img));
-
-        } catch (const exrio::DeepReaderException& e) {
-            LogError("Failed to load " + filename + ": " + e.what());
-            return 1;
-        } catch (const std::exception& e) {
-            LogError("Unexpected error loading " + filename + ": " + e.what());
-            return 1;
-        }
-        if (!exrio::isDeepEXR(filename)) {
-            LogError("File is not a deep EXR: " + filename);
-            return 1;
-        }
+    if (exrio::SaveImageInfo(opts, imagesInfo)) {
+        return 1;
     }
+
     int height = imagesInfo[0]->height();
     int width = imagesInfo[0]->width();
 

--- a/loom/src/utils.cc
+++ b/loom/src/utils.cc
@@ -1,6 +1,5 @@
 #include "utils.h"
-
-#include <algorithm>
+#include <iostream>
 #include <fstream>
 
 namespace deep_compositor {

--- a/loom/src/utils.cc
+++ b/loom/src/utils.cc
@@ -1,7 +1,9 @@
 #include "utils.h"
 
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 
 namespace deep_compositor {
 

--- a/loom/src/utils.cc
+++ b/loom/src/utils.cc
@@ -1,6 +1,7 @@
 #include "utils.h"
-#include <iostream>
+
 #include <fstream>
+#include <iostream>
 
 namespace deep_compositor {
 

--- a/loom/src/utils.h
+++ b/loom/src/utils.h
@@ -2,9 +2,6 @@
 #define LOOM_SRC_UTILS_H
 
 #include <chrono>
-#include <iomanip>
-#include <iostream>
-#include <sstream>
 #include <string>
 
 namespace deep_compositor {

--- a/loom/src/utils.h
+++ b/loom/src/utils.h
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <string>
+#include <algorithm>
 
 namespace deep_compositor {
 

--- a/loom/src/utils.h
+++ b/loom/src/utils.h
@@ -1,9 +1,9 @@
 #ifndef LOOM_SRC_UTILS_H
 #define LOOM_SRC_UTILS_H
 
+#include <algorithm>
 #include <chrono>
 #include <string>
-#include <algorithm>
 
 namespace deep_compositor {
 

--- a/loom/tests/assets/layer_fog.exr
+++ b/loom/tests/assets/layer_fog.exr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7290d343d82b99f4e920228a18c6c3eba2e96816d8c60d346ed30c7eae54e785
+size 19414332

--- a/loom/tests/assets/layer_objects.exr
+++ b/loom/tests/assets/layer_objects.exr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7847c9db2cc66f359c1d3b57645977a4deddd289b8c07252ffdbc5d1a09cfe3f
+size 6321908

--- a/loom/tests/unit/test_stress.cc
+++ b/loom/tests/unit/test_stress.cc
@@ -13,24 +13,22 @@ namespace fs = std::filesystem;
 
 class StressTest : public ::testing::Test {
   protected:
-  // Simple options for testing a loom instance
-  Options simple_opts = {
-      .input_files = {},
-      .input_z_offsets = {},
-      .output_prefix = "",
-      .deep_output = false,
-      .flat_output = true,
-      .png_output = true,
-      .verbose = false,
-      .merge_threshold = 0.001f,
-      .show_help = false,
-      .mod_offset = false,
-      .enable_merging = true
-  };
+    // Simple options for testing a loom instance
+    Options simple_opts = {.input_files = {},
+                           .input_z_offsets = {},
+                           .output_prefix = "",
+                           .deep_output = false,
+                           .flat_output = true,
+                           .png_output = true,
+                           .verbose = false,
+                           .merge_threshold = 0.001f,
+                           .show_help = false,
+                           .mod_offset = false,
+                           .enable_merging = true};
 
-  fs::path current_file = __FILE__;
-  fs::path tests_dir = current_file.parent_path().parent_path();
-  fs::path assets_dir = tests_dir / "assets";
+    fs::path current_file = __FILE__;
+    fs::path tests_dir = current_file.parent_path().parent_path();
+    fs::path assets_dir = tests_dir / "assets";
 };
 
 // ============================================================================
@@ -39,7 +37,8 @@ class StressTest : public ::testing::Test {
 
 TEST_F(StressTest, VolumetricSplittingStress) {
     Options opts = simple_opts;
-    std::vector<std::string> input_files = {assets_dir / "layer_fog.exr", assets_dir / "layer_objects.exr"};
+    std::vector<std::string> input_files = {assets_dir / "layer_fog.exr",
+                                            assets_dir / "layer_objects.exr"};
     opts.input_files = input_files;
 
     std::vector<std::unique_ptr<deep_compositor::DeepInfo>> imagesInfo;

--- a/loom/tests/unit/test_stress.cc
+++ b/loom/tests/unit/test_stress.cc
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <fstream>
-#include <streambuf>
+#include <filesystem>
 #include <vector>
 
 #include "composite_pipeline.h"

--- a/loom/tests/unit/test_stress.cc
+++ b/loom/tests/unit/test_stress.cc
@@ -1,11 +1,15 @@
 #include <gtest/gtest.h>
 
+#include <fstream>
+#include <streambuf>
 #include <vector>
 
 #include "composite_pipeline.h"
 #include "deep_compositor.h"
 #include "deep_info.h"
 #include "deep_options.h"
+
+namespace fs = std::filesystem;
 
 class StressTest : public ::testing::Test {
   protected:
@@ -23,6 +27,10 @@ class StressTest : public ::testing::Test {
       .mod_offset = false,
       .enable_merging = true
   };
+
+  fs::path current_file = __FILE__;
+  fs::path tests_dir = current_file.parent_path().parent_path();
+  fs::path assets_dir = tests_dir / "assets";
 };
 
 // ============================================================================
@@ -31,11 +39,11 @@ class StressTest : public ::testing::Test {
 
 TEST_F(StressTest, VolumetricSplittingStress) {
     Options opts = simple_opts;
-    std::vector<std::string> input_files = {"../assets/layer_fog.exr", "../assets/layer_objects.exr"};
+    std::vector<std::string> input_files = {assets_dir / "layer_fog.exr", assets_dir / "layer_objects.exr"};
     opts.input_files = input_files;
 
     std::vector<std::unique_ptr<deep_compositor::DeepInfo>> imagesInfo;
-    ASSERT_FALSE(exrio::SaveImageInfo(opts, imagesInfo));
+    ASSERT_EQ(exrio::SaveImageInfo(opts, imagesInfo), 0);
 
     int height = imagesInfo[0]->height();
     int width = imagesInfo[0]->width();

--- a/loom/tests/unit/test_stress.cc
+++ b/loom/tests/unit/test_stress.cc
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "composite_pipeline.h"
+#include "deep_compositor.h"
+#include "deep_info.h"
+#include "deep_options.h"
+
+class StressTest : public ::testing::Test {
+  protected:
+  // Simple options for testing a loom instance
+  Options simple_opts = {
+      .input_files = {},
+      .input_z_offsets = {},
+      .output_prefix = "",
+      .deep_output = false,
+      .flat_output = true,
+      .png_output = true,
+      .verbose = false,
+      .merge_threshold = 0.001f,
+      .show_help = false,
+      .mod_offset = false,
+      .enable_merging = true
+  };
+};
+
+// ============================================================================
+// Many Objects in smoke to test volumetric splitting
+// ============================================================================
+
+TEST_F(StressTest, VolumetricSplittingStress) {
+    Options opts = simple_opts;
+    std::vector<std::string> input_files = {"../assets/layer_fog.exr", "../assets/layer_objects.exr"};
+    opts.input_files = input_files;
+
+    std::vector<std::unique_ptr<deep_compositor::DeepInfo>> imagesInfo;
+    ASSERT_FALSE(exrio::SaveImageInfo(opts, imagesInfo));
+
+    int height = imagesInfo[0]->height();
+    int width = imagesInfo[0]->width();
+    ASSERT_NO_FATAL_FAILURE(deep_compositor::ProcessAllEXR(opts, height, width, imagesInfo));
+}


### PR DESCRIPTION
Fixes the root cause of issue #124 by allocating output capacity based on the true per‑pixel maximum (not the row‑wide total), so the per‑pixel write during merge cannot exceed the allocated buffer.

This would of course finally close #124 