### PR TITLE
[refactor] dashboard resilience

### DIFF
--- a/apps/scene-previewer/src/App.tsx
+++ b/apps/scene-previewer/src/App.tsx
@@ -486,7 +486,7 @@ function App() {
 	}, [scene]);
 
 	useEffect(() => {
-		resumePendingJobs();
+		void resumePendingJobs();
 	}, []);
 
 	useEffect(() => {

--- a/apps/scene-previewer/src/components/JobsModal.module.css
+++ b/apps/scene-previewer/src/components/JobsModal.module.css
@@ -85,6 +85,7 @@
 	opacity: 0.85;
 }
 
+.refreshBtn,
 .clearBtn {
 	margin-left: auto;
 	display: inline-flex;
@@ -95,6 +96,10 @@
 	border-right: none;
 	border: 1px solid var(--border-mid);
 	font-size: 10.5px;
+}
+
+.clearBtn {
+	margin-left: 0;
 }
 
 .clearBtn:disabled {
@@ -281,6 +286,12 @@
 
 .rowError {
 	color: var(--red);
+	font-size: 10.5px;
+	margin-top: 4px;
+}
+
+.rowSync {
+	color: var(--amber);
 	font-size: 10.5px;
 	margin-top: 4px;
 }

--- a/apps/scene-previewer/src/components/JobsModal.tsx
+++ b/apps/scene-previewer/src/components/JobsModal.tsx
@@ -7,7 +7,13 @@ import {
 	Trash2,
 	X,
 } from "lucide-react";
-import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+	useSyncExternalStore,
+} from "react";
 import { createPortal } from "react-dom";
 import type {
 	CloudJob,
@@ -15,6 +21,8 @@ import type {
 } from "../services/cloud-job-types";
 import {
 	downloadCompositePng,
+	refreshCloudJob,
+	refreshCloudJobs,
 	startCloudRender,
 	userCancelRender,
 } from "../services/cloud-render";
@@ -102,6 +110,7 @@ function JobRow({
 	onDownload,
 	onCancel,
 	onRemove,
+	onRefresh,
 	canRetry,
 }: {
 	job: CloudJob;
@@ -111,6 +120,7 @@ function JobRow({
 	onDownload: () => void;
 	onCancel: () => void;
 	onRemove: () => void;
+	onRefresh: () => void;
 	canRetry: boolean;
 }) {
 	const tone = statusTone(job);
@@ -190,6 +200,11 @@ function JobRow({
 						{job.error}
 					</div>
 				) : null}
+				{job.lastSyncError ? (
+					<div className={j.rowSync} role="status">
+						Last status check failed; retrying. {job.lastSyncError}
+					</div>
+				) : null}
 				{expanded && job.renderConfig ? (
 					<div className={j.detail}>
 						<div className={j.detailRow}>
@@ -262,6 +277,17 @@ function JobRow({
 						<span>Retry</span>
 					</button>
 				) : null}
+				{(job.status === "submitting" || job.status === "running") &&
+				!job.id.startsWith("local-") ? (
+					<button
+						type="button"
+						className={`${u.openBtn} ${j.action}`}
+						onClick={onRefresh}
+					>
+						<RefreshCw size={12} />
+						<span>Refresh</span>
+					</button>
+				) : null}
 				{job.status === "running" ? (
 					<button
 						type="button"
@@ -308,6 +334,10 @@ export function JobsModal({
 	const jobs = useJobs();
 	const [filter, setFilter] = useState<Filter>("all");
 	const [expandedId, setExpandedId] = useState<string | null>(null);
+
+	useEffect(() => {
+		refreshCloudJobs();
+	}, []);
 
 	const counts = useMemo(() => {
 		let running = 0;
@@ -395,6 +425,15 @@ export function JobsModal({
 					</div>
 					<button
 						type="button"
+						className={`${u.openBtn} ${j.refreshBtn}`}
+						onClick={refreshCloudJobs}
+						title="Refresh cloud render statuses"
+					>
+						<RefreshCw size={12} />
+						<span>Refresh</span>
+					</button>
+					<button
+						type="button"
 						className={`${u.openBtn} ${j.clearBtn}`}
 						disabled={completedCount === 0}
 						onClick={clearCompleted}
@@ -441,6 +480,7 @@ export function JobsModal({
 									onDownload={() => onDownload(j.id)}
 									onCancel={() => void userCancelRender(j.id)}
 									onRemove={() => onRemove(j.id)}
+									onRefresh={() => refreshCloudJob(j.id)}
 									canRetry={!!scene && !!dirHandle}
 								/>
 							))}

--- a/apps/scene-previewer/src/services/cloud-job-types.ts
+++ b/apps/scene-previewer/src/services/cloud-job-types.ts
@@ -1,12 +1,16 @@
-export type CloudJobStatus =
+export type CloudJobClientStatus =
 	| "packaging"
 	| "uploading-init"
 	| "uploading"
-	| "submitting"
+	| "submitting";
+
+export type CloudJobServerStatus =
 	| "running"
 	| "succeeded"
 	| "failed"
 	| "cancelled";
+
+export type CloudJobStatus = CloudJobClientStatus | CloudJobServerStatus;
 
 export interface CloudJobRenderConfig {
 	width: number;
@@ -33,6 +37,9 @@ export interface CloudJob {
 	totalBytes?: number;
 	uploadedBytes?: number;
 	error?: string;
+	lastSyncedAt?: number;
+	lastSyncError?: string;
+	compositeName?: string;
 	compositeObjectURL?: string;
 	abort?: AbortController;
 	renderConfig?: CloudJobRenderConfig;

--- a/apps/scene-previewer/src/services/cloud-render.ts
+++ b/apps/scene-previewer/src/services/cloud-render.ts
@@ -25,11 +25,18 @@ export type {
 export { isNonTerminalStatus } from "./jobs-store";
 
 const UPLOAD_CONCURRENCY = 8;
+const INITIAL_POLL_MS = 2000;
 const MAX_POLL_MS = 10_000;
 const COMPOSITE_FALLBACK = "frame-0001.png";
 
+const activePolls = new Map<string, AbortController>();
+
 function sleep(ms: number) {
 	return new Promise((r) => setTimeout(r, ms));
+}
+
+function isLocalJob(id: string): boolean {
+	return id.startsWith("local-");
 }
 
 function compositePngName(status: StatusResponse): string {
@@ -64,72 +71,154 @@ async function ensureSignedIn() {
 	await signInWithGoogle();
 }
 
-function markFailed(id: string, message: string) {
-	const exists = store.getSnapshot().some((j) => j.id === id);
-	if (exists) {
-		store.patchJob(id, { status: "failed" as CloudJobStatus, error: message });
+function jobExists(id: string): boolean {
+	return store.getSnapshot().some((j) => j.id === id);
+}
+
+function patchIfExists(id: string, patch: Partial<CloudJob>) {
+	if (jobExists(id)) {
+		store.patchJob(id, patch);
 	}
+}
+
+function markFailed(id: string, message: string) {
+	patchIfExists(id, {
+		status: "failed" as CloudJobStatus,
+		error: message,
+		lastSyncError: undefined,
+	});
+}
+
+function markSyncError(id: string, message: string) {
+	patchIfExists(id, { lastSyncError: message });
+}
+
+function markSynced(id: string, patch: Partial<CloudJob>) {
+	patchIfExists(id, {
+		...patch,
+		lastSyncedAt: Date.now(),
+		lastSyncError: undefined,
+	});
+}
+
+async function refetchCompositePreview(id: string, name?: string) {
+	const job = store.getSnapshot().find((j) => j.id === id);
+	const artifactName = name ?? job?.compositeName ?? COMPOSITE_FALLBACK;
+	try {
+		const blob = await fetchCompositeBlob(id, artifactName);
+		const url = URL.createObjectURL(blob);
+		store.patchJob(id, {
+			compositeName: artifactName,
+			compositeObjectURL: url,
+			lastSyncError: undefined,
+		});
+	} catch (e) {
+		markSyncError(
+			id,
+			`Composite preview unavailable: ${e instanceof Error ? e.message : String(e)}`,
+		);
+	}
+}
+
+async function reconcileJobStatus(
+	pipelineId: string,
+	signal: AbortSignal,
+): Promise<boolean> {
+	let st: Awaited<ReturnType<typeof getJobStatus>>;
+	try {
+		st = await getJobStatus(pipelineId);
+	} catch (e) {
+		markSyncError(pipelineId, e instanceof Error ? e.message : String(e));
+		return false;
+	}
+
+	if (signal.aborted) return true;
+
+	if (st === "pending") {
+		markSynced(pipelineId, { status: "submitting" });
+		return false;
+	}
+
+	const s = st.status;
+	if (s === "PIPELINE_STATUS_RUNNING" || s === "PIPELINE_STATUS_UNSPECIFIED") {
+		markSynced(pipelineId, { status: "running", error: undefined });
+		return false;
+	}
+	if (s === "PIPELINE_STATUS_SUCCEEDED") {
+		const name = compositePngName(st);
+		markSynced(pipelineId, {
+			status: "succeeded",
+			compositeName: name,
+			error: undefined,
+		});
+		if (!signal.aborted) {
+			await refetchCompositePreview(pipelineId, name);
+		}
+		return true;
+	}
+	if (s === "PIPELINE_STATUS_FAILED") {
+		markSynced(pipelineId, {
+			status: "failed",
+			error: st.error_message || "Render failed",
+		});
+		return true;
+	}
+	if (s === "PIPELINE_STATUS_CANCELLED") {
+		markSynced(pipelineId, { status: "cancelled", error: undefined });
+		return true;
+	}
+
+	markSyncError(pipelineId, `Unknown pipeline status: ${s}`);
+	return false;
 }
 
 async function pollUntilDone(
 	pipelineId: string,
 	signal: AbortSignal,
 ): Promise<void> {
-	let delay = 2000;
+	let delay = INITIAL_POLL_MS;
 	for (;;) {
-		if (signal.aborted) {
-			return;
-		}
-		let st: Awaited<ReturnType<typeof getJobStatus>>;
-		try {
-			st = await getJobStatus(pipelineId);
-		} catch (e) {
-			markFailed(pipelineId, e instanceof Error ? e.message : String(e));
-			return;
-		}
-		if (st === "pending") {
-			store.patchJob(pipelineId, { status: "running" });
-		} else {
-			const s = st.status;
-			if (
-				s === "PIPELINE_STATUS_RUNNING" ||
-				s === "PIPELINE_STATUS_UNSPECIFIED"
-			) {
-				store.patchJob(pipelineId, { status: "running" });
-			} else if (s === "PIPELINE_STATUS_SUCCEEDED") {
-				const name = compositePngName(st);
-				try {
-					if (signal.aborted) {
-						return;
-					}
-					const blob = await fetchCompositeBlob(pipelineId, name);
-					const url = URL.createObjectURL(blob);
-					store.patchJob(pipelineId, {
-						status: "succeeded",
-						compositeObjectURL: url,
-					});
-				} catch (e) {
-					markFailed(
-						pipelineId,
-						`Composite download failed: ${e instanceof Error ? e.message : String(e)}`,
-					);
-				}
-				return;
-			} else if (s === "PIPELINE_STATUS_FAILED") {
-				store.patchJob(pipelineId, {
-					status: "failed",
-					error: st.error_message || "Render failed",
-				});
-				return;
-			} else if (s === "PIPELINE_STATUS_CANCELLED") {
-				store.patchJob(pipelineId, { status: "cancelled" });
-				return;
-			}
-		}
-		const wait = signal.aborted ? 0 : delay;
-		if (wait > 0) await sleep(wait);
 		if (signal.aborted) return;
+		const done = await reconcileJobStatus(pipelineId, signal);
+		if (done || signal.aborted) return;
+		await sleep(delay);
 		delay = Math.min(MAX_POLL_MS, Math.floor(delay * 1.4));
+	}
+}
+
+function startStatusPoll(
+	pipelineId: string,
+	ac = new AbortController(),
+	force = false,
+) {
+	if (isLocalJob(pipelineId)) return;
+	const existing = activePolls.get(pipelineId);
+	if (existing && !existing.signal.aborted) {
+		if (!force) return;
+		existing.abort();
+	}
+	activePolls.set(pipelineId, ac);
+	store.patchJob(pipelineId, { abort: ac });
+	void pollUntilDone(pipelineId, ac.signal).finally(() => {
+		if (activePolls.get(pipelineId) === ac) {
+			activePolls.delete(pipelineId);
+		}
+	});
+}
+
+async function pollTracked(
+	pipelineId: string,
+	ac: AbortController,
+): Promise<void> {
+	if (isLocalJob(pipelineId)) return;
+	activePolls.set(pipelineId, ac);
+	store.patchJob(pipelineId, { abort: ac });
+	try {
+		await pollUntilDone(pipelineId, ac.signal);
+	} finally {
+		if (activePolls.get(pipelineId) === ac) {
+			activePolls.delete(pipelineId);
+		}
 	}
 }
 
@@ -174,6 +263,7 @@ export async function startCloudRender(args: {
 			totalFiles: bundle.length,
 			totalBytes,
 			uploadedBytes: 0,
+			lastSyncError: undefined,
 		});
 
 		const init = await initJob({
@@ -189,6 +279,7 @@ export async function startCloudRender(args: {
 		store.patchJob(activeId, {
 			id: pipelineId,
 			status: "uploading",
+			lastSyncError: undefined,
 		});
 		activeId = pipelineId;
 
@@ -217,16 +308,15 @@ export async function startCloudRender(args: {
 		);
 
 		if (ac.signal.aborted) return;
-		store.patchJob(activeId, { status: "submitting" });
+		store.patchJob(activeId, {
+			status: "submitting",
+			lastSyncError: undefined,
+		});
 		await submitJob(activeId, { enable_cache: enableCache });
 		if (ac.signal.aborted) return;
 		store.patchJob(activeId, { status: "running" });
-		await pollUntilDone(activeId, ac.signal);
+		await pollTracked(activeId, ac);
 	} catch (e) {
-		if (e instanceof ApiError) {
-			fail(e.message);
-			return;
-		}
 		if (e instanceof DOMException && e.name === "AbortError") {
 			store.removeJob(activeId);
 			return;
@@ -234,6 +324,19 @@ export async function startCloudRender(args: {
 		if (inBundlePhase) {
 			store.removeJob(activeId);
 			throw e;
+		}
+		if (e instanceof ApiError) {
+			fail(e.message);
+			return;
+		}
+		const current = store.getSnapshot().find((j) => j.id === activeId);
+		if (current?.status === "submitting" && !isLocalJob(activeId)) {
+			markSyncError(
+				activeId,
+				`Submit result unknown: ${e instanceof Error ? e.message : String(e)}`,
+			);
+			startStatusPoll(activeId, ac, true);
+			return;
 		}
 		fail(e instanceof Error ? e.message : String(e));
 	}
@@ -245,33 +348,26 @@ export async function userCancelRender(id: string) {
 	try {
 		await cancelJob(id);
 	} catch {
-		// not submitted, or already ended
+		markSyncError(id, "Cancel request failed; refreshing server status.");
+		startStatusPoll(id, new AbortController(), true);
+		return;
 	}
-	if (store.getSnapshot().some((x) => x.id === id)) {
-		store.patchJob(id, { status: "cancelled" });
-	}
-}
-
-async function refetchCompositePreview(id: string) {
-	try {
-		const blob = await fetchCompositeBlob(id, COMPOSITE_FALLBACK);
-		const url = URL.createObjectURL(blob);
-		store.patchJob(id, { compositeObjectURL: url });
-	} catch {
-		// keep card without image
+	if (jobExists(id)) {
+		store.patchJob(id, { status: "cancelled", lastSyncError: undefined });
 	}
 }
 
-export function resumePendingJobs() {
+export async function resumePendingJobs() {
+	await store.whenHydrated();
 	for (const j of store.getSnapshot()) {
-		if (j.id.startsWith("local-") && store.isNonTerminalStatus(j.status)) {
+		if (isLocalJob(j.id) && store.isNonTerminalStatus(j.status)) {
 			store.patchJob(j.id, {
 				status: "failed",
 				error: "Client restarted before job was created on the server.",
 			});
 			continue;
 		}
-		if (j.id.startsWith("local-")) {
+		if (isLocalJob(j.id)) {
 			continue;
 		}
 		if (
@@ -286,9 +382,7 @@ export function resumePendingJobs() {
 			continue;
 		}
 		if (j.status === "submitting" || j.status === "running") {
-			const ac = new AbortController();
-			store.patchJob(j.id, { abort: ac });
-			void pollUntilDone(j.id, ac.signal);
+			startStatusPoll(j.id);
 			continue;
 		}
 		if (j.status === "succeeded" && !j.compositeObjectURL) {
@@ -297,11 +391,43 @@ export function resumePendingJobs() {
 	}
 }
 
+export function refreshCloudJob(id: string) {
+	const job = store.getSnapshot().find((j) => j.id === id);
+	if (!job || isLocalJob(id)) return;
+	if (job.status === "succeeded") {
+		void refetchCompositePreview(id);
+		return;
+	}
+	if (store.isNonTerminalStatus(job.status)) {
+		startStatusPoll(id, new AbortController(), true);
+		return;
+	}
+	const ac = new AbortController();
+	void reconcileJobStatus(id, ac.signal);
+}
+
+export function refreshCloudJobs() {
+	for (const job of store.getSnapshot()) {
+		if (isLocalJob(job.id)) continue;
+		if (job.status === "succeeded" && !job.compositeObjectURL) {
+			void refetchCompositePreview(job.id);
+			continue;
+		}
+		if (store.isNonTerminalStatus(job.status)) {
+			startStatusPoll(job.id, new AbortController(), true);
+		}
+	}
+}
+
 export async function downloadCompositePng(
 	pipelineId: string,
 	suggestedName: string,
 ) {
-	const blob = await fetchCompositeBlob(pipelineId, COMPOSITE_FALLBACK);
+	const job = store.getSnapshot().find((j) => j.id === pipelineId);
+	const blob = await fetchCompositeBlob(
+		pipelineId,
+		job?.compositeName ?? COMPOSITE_FALLBACK,
+	);
 	const url = URL.createObjectURL(blob);
 	const a = document.createElement("a");
 	a.href = url;

--- a/apps/scene-previewer/src/services/jobs-store.ts
+++ b/apps/scene-previewer/src/services/jobs-store.ts
@@ -143,10 +143,10 @@ function clearLegacyJobs() {
 function mergeJobs(preferred: CloudJob[], fallback: CloudJob[]): CloudJob[] {
 	const byId = new Map<string, CloudJob>();
 	for (const job of fallback) {
-		byId.set(job.id, { ...job });
+		byId.set(job.id, normalizeJob(job));
 	}
 	for (const job of preferred) {
-		byId.set(job.id, { ...job });
+		byId.set(job.id, normalizeJob(job));
 	}
 	return pruneList([...byId.values()]);
 }

--- a/apps/scene-previewer/src/services/jobs-store.ts
+++ b/apps/scene-previewer/src/services/jobs-store.ts
@@ -1,13 +1,22 @@
 import type {
 	CloudJob,
+	CloudJobClientStatus,
 	CloudJobRenderConfig,
 	CloudJobStatus,
 } from "./cloud-job-types";
+import { CLOUD_JOBS_STORE, openPreviewerDB } from "./previewer-db";
 
-export type { CloudJob, CloudJobRenderConfig, CloudJobStatus };
+export type {
+	CloudJob,
+	CloudJobClientStatus,
+	CloudJobRenderConfig,
+	CloudJobStatus,
+};
 
-const LS_KEY = "skewer.jobs.v1";
+const LEGACY_LS_KEY = "skewer.jobs.v1";
 const MAX_JOBS = 20;
+
+type PersistedCloudJob = Omit<CloudJob, "abort" | "compositeObjectURL">;
 
 const terminal: Set<CloudJobStatus> = new Set([
 	"succeeded",
@@ -15,54 +24,181 @@ const terminal: Set<CloudJobStatus> = new Set([
 	"cancelled",
 ]);
 
+const clientOwned: Set<CloudJobStatus> = new Set([
+	"packaging",
+	"uploading-init",
+	"uploading",
+	"submitting",
+]);
+
 function isTerminal(s: CloudJobStatus): boolean {
 	return terminal.has(s);
 }
 
-let jobs: CloudJob[] = (() => {
-	try {
-		const raw = localStorage.getItem(LS_KEY);
-		if (!raw) return [];
-		return JSON.parse(raw) as CloudJob[];
-	} catch {
-		return [];
-	}
-})();
+function sortJobs(list: CloudJob[]): CloudJob[] {
+	return [...list].sort((a, b) => b.createdAt - a.createdAt);
+}
 
-const listeners = new Set<() => void>();
+function stripRuntimeFields(j: CloudJob): PersistedCloudJob {
+	const { abort, compositeObjectURL, ...rest } = j;
+	void abort;
+	void compositeObjectURL;
+	return rest;
+}
 
-function persist() {
-	const stripped = jobs.map((j) => {
-		// Drop runtime-only fields
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const { abort, compositeObjectURL, ...rest } = j;
-		return rest;
-	});
-	try {
-		localStorage.setItem(LS_KEY, JSON.stringify(stripped));
-	} catch {
-		// storage full, etc.
+function revokeObjectURL(j: CloudJob | undefined) {
+	if (j?.compositeObjectURL) {
+		URL.revokeObjectURL(j.compositeObjectURL);
 	}
 }
 
-function emit() {
-	persist();
-	for (const l of listeners) l();
-}
-
-function prune() {
-	while (jobs.length > MAX_JOBS) {
-		const terminals = jobs.filter((j) => isTerminal(j.status));
-		if (terminals.length === 0) return;
+function pruneList(list: CloudJob[]): CloudJob[] {
+	let next = sortJobs(list);
+	while (next.length > MAX_JOBS) {
+		const terminals = next.filter((j) => isTerminal(j.status));
+		if (terminals.length === 0) return next;
 		const drop = terminals.reduce((a, b) =>
 			a.createdAt < b.createdAt ? a : b,
 		);
-		const i = jobs.findIndex((j) => j.id === drop.id);
-		if (i < 0) return;
-		const url = jobs[i]?.compositeObjectURL;
-		if (url) URL.revokeObjectURL(url);
-		jobs = jobs.filter((j) => j.id !== drop.id);
+		revokeObjectURL(next.find((j) => j.id === drop.id));
+		next = next.filter((j) => j.id !== drop.id);
 	}
+	return next;
+}
+
+function normalizeJob(j: CloudJob): CloudJob {
+	return { ...j };
+}
+
+let jobs: CloudJob[] = [];
+let hydrated = false;
+let pendingPersist = false;
+let persistInFlight = false;
+const listeners = new Set<() => void>();
+
+function emit() {
+	for (const l of listeners) l();
+}
+
+function publish(nextJobs: CloudJob[], persist = true) {
+	jobs = pruneList(nextJobs).map(normalizeJob);
+	emit();
+	if (persist && hydrated) {
+		schedulePersist();
+	}
+}
+
+function requestAll<T>(store: IDBObjectStore): Promise<T[]> {
+	return new Promise((resolve, reject) => {
+		const req = store.getAll();
+		req.onsuccess = () => resolve(req.result as T[]);
+		req.onerror = () => reject(req.error);
+	});
+}
+
+async function readPersistedJobs(): Promise<CloudJob[]> {
+	const db = await openPreviewerDB();
+	const tx = db.transaction(CLOUD_JOBS_STORE, "readonly");
+	const store = tx.objectStore(CLOUD_JOBS_STORE);
+	const rows = await requestAll<PersistedCloudJob>(store);
+	return rows.map(normalizeJob);
+}
+
+async function writePersistedJobs(snapshot: CloudJob[]): Promise<void> {
+	const db = await openPreviewerDB();
+	const tx = db.transaction(CLOUD_JOBS_STORE, "readwrite");
+	const store = tx.objectStore(CLOUD_JOBS_STORE);
+	store.clear();
+	for (const job of snapshot.map(stripRuntimeFields)) {
+		store.put(job);
+	}
+	await new Promise<void>((resolve, reject) => {
+		tx.oncomplete = () => resolve();
+		tx.onerror = () => reject(tx.error);
+		tx.onabort = () => reject(tx.error);
+	});
+}
+
+function readLegacyJobs(): CloudJob[] {
+	try {
+		const raw = localStorage.getItem(LEGACY_LS_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw) as CloudJob[];
+		return Array.isArray(parsed)
+			? parsed.map((j) => stripRuntimeFields(j))
+			: [];
+	} catch {
+		return [];
+	}
+}
+
+function clearLegacyJobs() {
+	try {
+		localStorage.removeItem(LEGACY_LS_KEY);
+	} catch {
+		// noop
+	}
+}
+
+function mergeJobs(preferred: CloudJob[], fallback: CloudJob[]): CloudJob[] {
+	const byId = new Map<string, CloudJob>();
+	for (const job of fallback) {
+		byId.set(job.id, { ...job });
+	}
+	for (const job of preferred) {
+		byId.set(job.id, { ...job });
+	}
+	return pruneList([...byId.values()]);
+}
+
+function schedulePersist() {
+	pendingPersist = true;
+	if (!persistInFlight) {
+		void flushPersist();
+	}
+}
+
+async function flushPersist() {
+	persistInFlight = true;
+	try {
+		while (pendingPersist) {
+			pendingPersist = false;
+			const snapshot = jobs.map(normalizeJob);
+			await writePersistedJobs(snapshot);
+		}
+	} catch {
+		// Job history is a cache; keep the in-memory state authoritative for UI.
+	} finally {
+		persistInFlight = false;
+		if (pendingPersist) {
+			void flushPersist();
+		}
+	}
+}
+
+async function hydrateJobs() {
+	const legacy = readLegacyJobs();
+	try {
+		const persisted = await readPersistedJobs();
+		hydrated = true;
+		jobs = mergeJobs(jobs, mergeJobs(persisted, legacy));
+		emit();
+		schedulePersist();
+		clearLegacyJobs();
+	} catch {
+		hydrated = true;
+		if (legacy.length > 0) {
+			jobs = mergeJobs(jobs, legacy);
+			emit();
+			schedulePersist();
+		}
+	}
+}
+
+const hydrationPromise = hydrateJobs();
+
+export function whenHydrated(): Promise<void> {
+	return hydrationPromise;
 }
 
 export function subscribe(fn: () => void) {
@@ -77,71 +213,81 @@ export function getSnapshot(): CloudJob[] {
 }
 
 export function upsertJob(j: CloudJob) {
-	const i = jobs.findIndex((x) => x.id === j.id);
-	if (i >= 0) jobs[i] = j;
-	else {
-		jobs = [j, ...jobs];
-		prune();
-	}
-	emit();
+	const nextJob = normalizeJob(j);
+	const exists = jobs.some((x) => x.id === j.id);
+	const next = exists
+		? jobs.map((x) => (x.id === j.id ? nextJob : x))
+		: [nextJob, ...jobs];
+	publish(next);
 }
 
 export function patchJob(id: string, p: Partial<CloudJob>) {
 	const i = jobs.findIndex((j) => j.id === id);
 	if (i < 0) return;
-	const prevStatus = jobs[i].status;
+
+	const prev = jobs[i];
+	const prevStatus = prev.status;
 	const nextStatus = p.status ?? prevStatus;
 	const stamp: Partial<CloudJob> = {};
 	if (
 		!isTerminal(prevStatus) &&
 		isTerminal(nextStatus) &&
-		jobs[i].completedAt === undefined
+		prev.completedAt === undefined
 	) {
 		stamp.completedAt = Date.now();
 	}
-	const nextId = p.id;
-	if (nextId && nextId !== id) {
-		const cur = { ...jobs[i], ...p, ...stamp, id: nextId };
-		jobs.splice(i, 1);
-		const j2 = jobs.findIndex((j) => j.id === nextId);
-		if (j2 >= 0) jobs[j2] = cur;
-		else jobs = [cur, ...jobs];
-	} else {
-		jobs[i] = { ...jobs[i], ...p, ...stamp };
+
+	const nextId = p.id && p.id !== id ? p.id : id;
+	if (
+		p.compositeObjectURL &&
+		prev.compositeObjectURL &&
+		p.compositeObjectURL !== prev.compositeObjectURL
+	) {
+		URL.revokeObjectURL(prev.compositeObjectURL);
 	}
-	prune();
-	emit();
+	const nextJob = normalizeJob({ ...prev, ...p, ...stamp, id: nextId });
+	let next = jobs.filter((j) => j.id !== id);
+	const existing = next.findIndex((j) => j.id === nextId);
+	if (existing >= 0) {
+		next = next.map((j) => (j.id === nextId ? nextJob : j));
+	} else {
+		next = [nextJob, ...next];
+	}
+	publish(next);
 }
 
 export function addUploadedBytes(id: string, delta: number) {
-	const i = jobs.findIndex((j) => j.id === id);
-	if (i < 0) return;
-	jobs[i] = {
-		...jobs[i],
-		uploadedBytes: (jobs[i].uploadedBytes ?? 0) + delta,
-	};
-	emit();
+	const next = jobs.map((j) =>
+		j.id === id
+			? {
+					...j,
+					uploadedBytes: (j.uploadedBytes ?? 0) + delta,
+				}
+			: j,
+	);
+	publish(next);
 }
 
 export function removeJob(id: string) {
-	const i = jobs.findIndex((j) => j.id === id);
-	if (i < 0) return;
-	if (jobs[i].compositeObjectURL) {
-		URL.revokeObjectURL(jobs[i].compositeObjectURL);
-	}
-	jobs = jobs.filter((j) => j.id !== id);
-	emit();
+	const existing = jobs.find((j) => j.id === id);
+	if (!existing) return;
+	revokeObjectURL(existing);
+	publish(
+		jobs.filter((j) => j.id !== id),
+		true,
+	);
 }
 
 export function clearCompleted() {
-	let changed = false;
-	jobs = jobs.filter((j) => {
-		if (!isTerminal(j.status)) return true;
-		if (j.compositeObjectURL) URL.revokeObjectURL(j.compositeObjectURL);
-		changed = true;
-		return false;
-	});
-	if (changed) emit();
+	const completed = jobs.filter((j) => isTerminal(j.status));
+	if (completed.length === 0) return;
+	for (const job of completed) {
+		revokeObjectURL(job);
+	}
+	publish(
+		jobs.filter((j) => !isTerminal(j.status)),
+		true,
+	);
 }
 
 export function isNonTerminalStatus(s: CloudJobStatus): boolean {
@@ -150,4 +296,8 @@ export function isNonTerminalStatus(s: CloudJobStatus): boolean {
 
 export function isTerminalStatus(s: CloudJobStatus): boolean {
 	return isTerminal(s);
+}
+
+export function isClientOwnedStatus(s: CloudJobStatus): boolean {
+	return clientOwned.has(s);
 }

--- a/apps/scene-previewer/src/services/previewer-db.ts
+++ b/apps/scene-previewer/src/services/previewer-db.ts
@@ -1,0 +1,22 @@
+export const PREVIEWER_DB_NAME = "skewer-previewer";
+export const PREVIEWER_DB_VERSION = 2;
+
+export const RECENT_SCENES_STORE = "recent-scenes";
+export const CLOUD_JOBS_STORE = "cloud-jobs";
+
+export function openPreviewerDB(): Promise<IDBDatabase> {
+	return new Promise((resolve, reject) => {
+		const req = indexedDB.open(PREVIEWER_DB_NAME, PREVIEWER_DB_VERSION);
+		req.onupgradeneeded = () => {
+			const db = req.result;
+			if (!db.objectStoreNames.contains(RECENT_SCENES_STORE)) {
+				db.createObjectStore(RECENT_SCENES_STORE, { keyPath: "name" });
+			}
+			if (!db.objectStoreNames.contains(CLOUD_JOBS_STORE)) {
+				db.createObjectStore(CLOUD_JOBS_STORE, { keyPath: "id" });
+			}
+		};
+		req.onsuccess = () => resolve(req.result);
+		req.onerror = () => reject(req.error);
+	});
+}

--- a/apps/scene-previewer/src/services/previewer-db.ts
+++ b/apps/scene-previewer/src/services/previewer-db.ts
@@ -16,7 +16,19 @@ export function openPreviewerDB(): Promise<IDBDatabase> {
 				db.createObjectStore(CLOUD_JOBS_STORE, { keyPath: "id" });
 			}
 		};
-		req.onsuccess = () => resolve(req.result);
+		req.onblocked = () =>
+			reject(
+				new Error(
+					`Opening IndexedDB "${PREVIEWER_DB_NAME}" was blocked by another open connection using an older version. Please close other tabs or reload and try again.`,
+				),
+			);
+		req.onsuccess = () => {
+			const db = req.result;
+			db.onversionchange = () => {
+				db.close();
+			};
+			resolve(db);
+		};
 		req.onerror = () => reject(req.error);
 	});
 }

--- a/apps/scene-previewer/src/services/recent-scenes.ts
+++ b/apps/scene-previewer/src/services/recent-scenes.ts
@@ -1,9 +1,8 @@
 // Persists recently opened scene folders using IndexedDB.
 // FileSystemDirectoryHandle objects can be stored in IDB but not localStorage.
 
-const DB_NAME = "skewer-previewer";
-const STORE_NAME = "recent-scenes";
-const DB_VERSION = 1;
+import { openPreviewerDB, RECENT_SCENES_STORE } from "./previewer-db";
+
 const MAX_ENTRIES = 8;
 
 export interface RecentEntry {
@@ -12,26 +11,12 @@ export interface RecentEntry {
 	lastOpened: number; // epoch ms
 }
 
-function openDB(): Promise<IDBDatabase> {
-	return new Promise((resolve, reject) => {
-		const req = indexedDB.open(DB_NAME, DB_VERSION);
-		req.onupgradeneeded = () => {
-			const db = req.result;
-			if (!db.objectStoreNames.contains(STORE_NAME)) {
-				db.createObjectStore(STORE_NAME, { keyPath: "name" });
-			}
-		};
-		req.onsuccess = () => resolve(req.result);
-		req.onerror = () => reject(req.error);
-	});
-}
-
 export async function getRecentScenes(): Promise<RecentEntry[]> {
 	try {
-		const db = await openDB();
+		const db = await openPreviewerDB();
 		return new Promise((resolve, reject) => {
-			const tx = db.transaction(STORE_NAME, "readonly");
-			const store = tx.objectStore(STORE_NAME);
+			const tx = db.transaction(RECENT_SCENES_STORE, "readonly");
+			const store = tx.objectStore(RECENT_SCENES_STORE);
 			const req = store.getAll();
 			req.onsuccess = () => {
 				const entries = req.result as RecentEntry[];
@@ -50,9 +35,9 @@ export async function addRecentScene(
 	handle: FileSystemDirectoryHandle,
 ): Promise<void> {
 	try {
-		const db = await openDB();
-		const tx = db.transaction(STORE_NAME, "readwrite");
-		const store = tx.objectStore(STORE_NAME);
+		const db = await openPreviewerDB();
+		const tx = db.transaction(RECENT_SCENES_STORE, "readwrite");
+		const store = tx.objectStore(RECENT_SCENES_STORE);
 		store.put({ name, handle, lastOpened: Date.now() } satisfies RecentEntry);
 
 		// Prune old entries
@@ -73,9 +58,9 @@ export async function addRecentScene(
 
 export async function removeRecentScene(name: string): Promise<void> {
 	try {
-		const db = await openDB();
-		const tx = db.transaction(STORE_NAME, "readwrite");
-		tx.objectStore(STORE_NAME).delete(name);
+		const db = await openPreviewerDB();
+		const tx = db.transaction(RECENT_SCENES_STORE, "readwrite");
+		tx.objectStore(RECENT_SCENES_STORE).delete(name);
 	} catch {
 		// noop
 	}


### PR DESCRIPTION
This PR refactors the dashboard to treat the server as the single source of truth for render status rather than watching http requests for state transitions. This avoids the fragile “one failed poll means failed render” behavior and fixes various modal state transition bugs.