### PR TITLE
[refactor] remove hard coded tf state bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ renders/
 *.tfstate.backup
 .terraform/
 terraform.tfvars
+deployments/terraform/backend.hcl
 
 # Go binaries
 /coordinator

--- a/deployments/terraform/README.md
+++ b/deployments/terraform/README.md
@@ -1,0 +1,36 @@
+# Terraform
+
+Each developer should keep Terraform state in their own GCS bucket so local cloud
+deployments do not share or overwrite state.
+
+Copy the backend example and edit the bucket name:
+
+```sh
+cp backend.example.hcl backend.hcl
+```
+
+Use a bucket tied to your project, for example:
+
+```hcl
+bucket = "my-project-id-skewer-tfstate"
+prefix = "skewer"
+```
+
+The bucket must exist before Terraform can initialize the backend. Then run:
+
+```sh
+terraform init -backend-config=backend.hcl
+```
+
+If this checkout was already initialized against a different backend, use:
+
+```sh
+terraform init -reconfigure -backend-config=backend.hcl
+```
+
+If you intentionally want to move existing state into your new bucket, use
+`-migrate-state` instead of `-reconfigure` and review Terraform's migration
+prompt carefully.
+
+Keep `backend.hcl` and `terraform.tfvars` uncommitted. Commit only the shared
+Terraform modules and example files.

--- a/deployments/terraform/backend.example.hcl
+++ b/deployments/terraform/backend.example.hcl
@@ -1,0 +1,4 @@
+# Copy to backend.hcl and set bucket to your private Terraform state bucket.
+# The bucket must already exist before running terraform init.
+bucket = "<your-gcp-project-id>-skewer-tfstate"
+prefix = "skewer"

--- a/deployments/terraform/main.tf
+++ b/deployments/terraform/main.tf
@@ -7,10 +7,7 @@ terraform {
     }
   }
 
-  backend "gcs" {
-    bucket = "skwr-ucd-tfstate"
-    prefix = "skewer"
-  }
+  backend "gcs" {}
 }
 
 provider "google" {


### PR DESCRIPTION
Each developer should keep Terraform state in their own GCS bucket so local cloud deployments do not share or overwrite state.

To setup:

Copy the backend example and edit the bucket name:

```sh
cp backend.example.hcl backend.hcl
```

Use a bucket tied to your project, for example:

```hcl
bucket = "my-project-id-skewer-tfstate"
prefix = "skewer"
```

```sh
terraform init -backend-config=backend.hcl
```

If you want to move existing state into a new bucket, use
`-migrate-state` instead of `-reconfigure`.

After this, `terraform apply` and such should be independent of each project.