### PR TITLE
[bugfix] Skip Tests on Image Push

### DIFF
--- a/deployments/docker/Dockerfile.loom
+++ b/deployments/docker/Dockerfile.loom
@@ -34,7 +34,7 @@ COPY . .
 # Use BuildKit cache mounts for ccache and CMake build directory
 RUN --mount=type=cache,id=loom-ccache,target=/ccache \
     --mount=type=cache,id=loom-build,target=/app/build,sharing=locked \
-    cmake --preset release -DSKEWER_COMBINED_BUILD_SKEWER=OFF && \
+    cmake --preset release -DSKEWER_COMBINED_BUILD_SKEWER=OFF -DBUILD_TESTING=OFF && \
     cmake --build --preset release --target loom-worker --parallel 4 && \
     cp /app/build/release/loom/loom-worker /tmp/loom-worker
 

--- a/deployments/docker/Dockerfile.skewer
+++ b/deployments/docker/Dockerfile.skewer
@@ -34,7 +34,7 @@ COPY . .
 # Use BuildKit cache mounts for ccache and CMake build directory
 RUN --mount=type=cache,id=skewer-ccache,target=/ccache \
     --mount=type=cache,id=skewer-build,target=/app/build,sharing=locked \
-    cmake --preset release -DSKEWER_COMBINED_BUILD_LOOM=OFF && \
+    cmake --preset release -DSKEWER_COMBINED_BUILD_LOOM=OFF -DBUILD_TESTING=OFF && \
     cmake --build --preset release --target skewer-worker --parallel 4 && \
     cp /app/build/release/skewer/skewer-worker /tmp/skewer-worker
 


### PR DESCRIPTION
We don't really need to include testing stuff in our final image so we should skip, especially since `tests/integration` is excluded in `.dockerignore`.