### PR TITLE
[bugfix] Render Settings Syncing

### DIFF
--- a/apps/scene-previewer/src/App.tsx
+++ b/apps/scene-previewer/src/App.tsx
@@ -54,7 +54,7 @@ import type {
 	SceneNode,
 	Vec3,
 } from "./types/scene";
-import { isAnimated } from "./types/scene";
+import { DEFAULT_RENDER_CONFIG, isAnimated } from "./types/scene";
 
 function isEditableTarget(target: EventTarget | null) {
 	if (!(target instanceof HTMLElement)) return false;
@@ -124,35 +124,17 @@ function App() {
 		"world",
 	);
 
-	const DEFAULT_RENDER_CONFIG: RenderConfig = useMemo(
-		() => ({
-			integrator: "path_trace",
-			max_samples: 128,
-			min_samples: 16,
-			max_depth: 8,
-			threads: 0,
-			noise_threshold: 0.01,
-			enable_deep: false,
-			image: { width: 1920, height: 1080 },
-		}),
-		[],
-	);
-
 	const renderSettings = scene?.settings ?? DEFAULT_RENDER_CONFIG;
 
-	const setSceneSettings = useCallback(
-		(s: ResolvedScene) => {
-			const loadedRender =
-				s.layers[0]?.data.render ?? s.contexts[0]?.data.render;
-			const sceneWithSettings: ResolvedScene = {
-				...s,
-				settings: loadedRender ?? DEFAULT_RENDER_CONFIG,
-			};
+	const setSceneSettings = useCallback((s: ResolvedScene) => {
+		const loadedRender = s.layers[0]?.data.render ?? s.contexts[0]?.data.render;
+		const sceneWithSettings: ResolvedScene = {
+			...s,
+			settings: loadedRender ?? DEFAULT_RENDER_CONFIG,
+		};
 
-			setScene(sceneWithSettings);
-		},
-		[DEFAULT_RENDER_CONFIG],
-	);
+		setScene(sceneWithSettings);
+	}, []);
 
 	const renderStartTime = scene?.animation.start ?? 0;
 	const renderEndTime = scene?.animation.end ?? 0;

--- a/apps/scene-previewer/src/App.tsx
+++ b/apps/scene-previewer/src/App.tsx
@@ -124,19 +124,36 @@ function App() {
 		"world",
 	);
 
-	const [renderSettings, setRenderSettings] = useState<RenderConfig>({
-		integrator: "path_trace",
-		max_samples: 128,
-		min_samples: 16,
-		max_depth: 8,
-		threads: 0,
-		noise_threshold: 0.01,
-		enable_deep: false,
-		image: {
-			width: 1920,
-			height: 1080,
+	const DEFAULT_RENDER_CONFIG: RenderConfig = useMemo(
+		() => ({
+			integrator: "path_trace",
+			max_samples: 128,
+			min_samples: 16,
+			max_depth: 8,
+			threads: 0,
+			noise_threshold: 0.01,
+			enable_deep: false,
+			image: { width: 1920, height: 1080 },
+		}),
+		[],
+	);
+
+	const renderSettings = scene?.settings ?? DEFAULT_RENDER_CONFIG;
+
+	const setSceneSettings = useCallback(
+		(s: ResolvedScene) => {
+			const loadedRender =
+				s.layers[0]?.data.render ?? s.contexts[0]?.data.render;
+			const sceneWithSettings: ResolvedScene = {
+				...s,
+				settings: loadedRender ?? DEFAULT_RENDER_CONFIG,
+			};
+
+			setScene(sceneWithSettings);
 		},
-	});
+		[DEFAULT_RENDER_CONFIG],
+	);
+
 	const renderStartTime = scene?.animation.start ?? 0;
 	const renderEndTime = scene?.animation.end ?? 0;
 	const renderFps = scene?.animation.fps ?? 24;
@@ -169,7 +186,7 @@ function App() {
 	const animRangeRef = useRef({ start: 0, end: 0 });
 
 	function handleSceneLoaded(s: ResolvedScene, dir: FileSystemDirectoryHandle) {
-		setScene(s);
+		setSceneSettings(s);
 		setDirHandle(dir);
 		setError("");
 		setSelectedObjectKey(null);
@@ -410,6 +427,24 @@ function App() {
 		[handleSceneEdit],
 	);
 
+	const handleRenderSettingsChange = useCallback(
+		(config: RenderConfig) => {
+			handleSceneEdit((s) => ({
+				...s,
+				settings: config,
+				layers: s.layers.map((l) => ({
+					...l,
+					data: { ...l.data, render: config },
+				})),
+				contexts: s.contexts.map((c) => ({
+					...c,
+					data: { ...c.data, render: config },
+				})),
+			}));
+		},
+		[handleSceneEdit],
+	);
+
 	function handleNavigateHome() {
 		if (
 			hasUnsavedChanges &&
@@ -641,7 +676,7 @@ function App() {
 							onAddMedium={handleAddMedium}
 							dirHandle={dirHandle}
 							renderSettings={renderSettings}
-							onRenderSettingsChange={setRenderSettings}
+							onRenderSettingsChange={handleRenderSettingsChange}
 							startTime={renderStartTime}
 							onStartTimeChange={setRenderStartTime}
 							endTime={renderEndTime}

--- a/apps/scene-previewer/src/App.tsx
+++ b/apps/scene-previewer/src/App.tsx
@@ -127,7 +127,9 @@ function App() {
 	const renderSettings = scene?.settings ?? DEFAULT_RENDER_CONFIG;
 
 	const setSceneSettings = useCallback((s: ResolvedScene) => {
-		const loadedRender = s.layers[0]?.data.render ?? s.contexts[0]?.data.render;
+		const loadedRender =
+			s.layers.find((l) => l.data.render != null)?.data.render ??
+			s.contexts.find((c) => c.data.render != null)?.data.render;
 		const sceneWithSettings: ResolvedScene = {
 			...s,
 			settings: loadedRender ?? DEFAULT_RENDER_CONFIG,

--- a/apps/scene-previewer/src/services/new-scene.ts
+++ b/apps/scene-previewer/src/services/new-scene.ts
@@ -3,7 +3,7 @@
 // and returns a parsed ResolvedScene — no read-after-write needed.
 
 import type { ResolvedScene } from "../types/scene";
-import { DEFAULT_ANIMATION } from "../types/scene";
+import { DEFAULT_ANIMATION, DEFAULT_RENDER_CONFIG } from "../types/scene";
 import { writeFile } from "./fs";
 import { parseLayerData, parseSceneManifest } from "./scene-parser";
 
@@ -66,5 +66,6 @@ export async function createNewScene(
 		],
 		output_dir: manifest.output_dir,
 		animation: manifest.animation ?? { ...DEFAULT_ANIMATION },
+		settings: DEFAULT_RENDER_CONFIG,
 	};
 }

--- a/apps/scene-previewer/src/services/scene-parser.ts
+++ b/apps/scene-previewer/src/services/scene-parser.ts
@@ -27,7 +27,7 @@ import type {
 	StaticTransform,
 	Vec3,
 } from "../types/scene";
-import { DEFAULT_ANIMATION } from "../types/scene";
+import { DEFAULT_ANIMATION, DEFAULT_RENDER_CONFIG } from "../types/scene";
 import { readJsonFile } from "./fs";
 import { getNanoVDBBounds } from "./nanovdb-parser";
 
@@ -559,6 +559,7 @@ export async function loadScene(
 		layers,
 		output_dir: manifest.output_dir,
 		animation: manifest.animation ?? { ...DEFAULT_ANIMATION },
+		settings: DEFAULT_RENDER_CONFIG,
 	};
 
 	// --- Volumetric Bounding Sphere Synchronization ---

--- a/apps/scene-previewer/src/types/scene.ts
+++ b/apps/scene-previewer/src/types/scene.ts
@@ -188,6 +188,17 @@ export const DEFAULT_ANIMATION: Animation = {
 	shutter_angle: 180,
 };
 
+export const DEFAULT_RENDER_CONFIG: RenderConfig = {
+	integrator: "path_trace",
+	max_samples: 128,
+	min_samples: 16,
+	max_depth: 8,
+	threads: 0,
+	noise_threshold: 0.01,
+	enable_deep: false,
+	image: { width: 1920, height: 1080 },
+};
+
 // --- scene.json top-level ---
 
 export interface SceneManifest {

--- a/apps/scene-previewer/src/types/scene.ts
+++ b/apps/scene-previewer/src/types/scene.ts
@@ -212,4 +212,5 @@ export interface ResolvedScene {
 	layers: ResolvedLayer[];
 	output_dir: string;
 	animation: Animation;
+	settings: RenderConfig;
 }


### PR DESCRIPTION
This PR forces the previewer to detect changes to the render settings including resolution, noise threshold, sampling, etc. and allow saving to the json files. By moving this information to `ResolvedScene`, this also allows for cloud bundling to detect and use the panel's settings as the source of truth.