### PR TITLE
[docs] Restore GCP Guide

### DIFF
--- a/docs/getting-started/gcp.md
+++ b/docs/getting-started/gcp.md
@@ -95,12 +95,18 @@ Install the following tools before beginning:
 
 ## Step 2: Configure Environment Variables
 
-1. Copy the example file:
+1. Clone the repository and change to the project root:
+   ```bash
+   git clone https://github.com/your-org/skewer.git
+   cd skewer
+   ```
+
+2. Copy the example file:
    ```bash
    cp apps/scene-previewer/.env.example apps/scene-previewer/.env
    ```
 
-2. Open `apps/scene-previewer/.env` and fill in the values from Step 2:
+3. Open `apps/scene-previewer/.env` and fill in the values from Step 2:
    ```
    VITE_API_URL=https://skewer-api-XXXXX.REGION.run.app         # filled in after Step 7
    VITE_FIREBASE_API_KEY=your_api_key                           # from Step 3.3

--- a/docs/getting-started/gcp.md
+++ b/docs/getting-started/gcp.md
@@ -164,7 +164,9 @@ Firebase needs an OAuth 2.0 Client ID to authenticate users via Google. This lin
 1. Open [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials) in the GCP Console
 2. Click **+ Create Credentials** → **OAuth client ID**
 3. If prompted, configure the OAuth consent screen:
-   - User Type: **Internal**
+   - **User Type**:
+     - Choose **Internal** only if your GCP project belongs to a Google Workspace or Cloud Identity organization.
+     - Choose **External** if you're using a personal Gmail account or an individual project, then add yourself as a test user if Google prompts you to do so.
    - App name: `Skewer Previewer` (or any name)
    - User support email: your email
    - Developer contact email: your email

--- a/docs/getting-started/gcp.md
+++ b/docs/getting-started/gcp.md
@@ -71,13 +71,6 @@ Install the following tools before beginning:
 | [Bun](https://bun.sh/docs/installation)                                  | latest          | [Install guide](https://bun.sh/docs/installation)                              |
 | [Git](https://git-scm.com/)                                              | latest          | [Install guide](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) |
 
-!!! note "Authentication"
-    After installing `gcloud`, authenticate and set your project:
-    ```bash
-    gcloud auth login
-    gcloud config set project YOUR_PROJECT_ID
-    ```
-
 ---
 
 ## Step 1: Create a Google Cloud Project
@@ -88,41 +81,23 @@ Install the following tools before beginning:
 4. Note the **Project ID** — you'll need it throughout this guide
 5. Click **Create**
 
+!!! note "Authentication"
+    After installing `gcloud`, authenticate and set your project:
+    ```bash
+    gcloud auth login
+    gcloud config set project YOUR_PROJECT_ID
+    ```
+
 !!! important "Billing Required"
     Ensure billing is enabled on your project. Go to [Billing](https://console.cloud.google.com/billing) and link a billing account. Education accounts (Google Cloud for Education) include credits that cover typical rendering workloads.
 
 ---
 
-## Step 2: Configure Environment Variables
-
-1. Clone the repository and change to the project root:
-   ```bash
-   git clone https://github.com/your-org/skewer.git
-   cd skewer
-   ```
-
-2. Copy the example file:
-   ```bash
-   cp apps/scene-previewer/.env.example apps/scene-previewer/.env
-   ```
-
-3. Open `apps/scene-previewer/.env` and fill in the values from Step 2:
-   ```
-   VITE_API_URL=https://skewer-api-XXXXX.REGION.run.app         # filled in after Step 7
-   VITE_FIREBASE_API_KEY=your_api_key                           # from Step 3.3
-   VITE_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com    # from Step 3.3
-   ```
-
-!!! note "API URL"
-    `VITE_API_URL` will be set after Terraform finishes deploying — the Cloud Run API URL is printed in the Terraform output as `api_url`.
-
----
-
-## Step 3: Set Up Firebase Authentication
+## Step 2: Set Up Firebase Authentication
 
 The scene previewer uses Firebase Authentication for Google sign-in. This lets users authenticate with their Google account and obtain an ID token that the Skewer API verifies.
 
-### 3.1 Create a Firebase Project
+### 2.1 Create a Firebase Project
 
 1. Open the [Firebase Console](https://console.firebase.google.com/)
 2. Click **Add project**
@@ -131,17 +106,27 @@ The scene previewer uses Firebase Authentication for Google sign-in. This lets u
 
 See [Add Firebase to your project](https://firebase.google.com/docs/projects/learn-more#add-resources-existing-gcp) for details.
 
-### 3.2 Enable Google Sign-In
+### 2.2 Google Sign-In Provider
+You do **not** need to manually add or enable the **Google** sign-in provider in the Firebase Console before running `terraform apply`. The Terraform configuration manages the Google Identity Platform provider automatically, but it needs your OAuth 2.0 credentials to do so.
 
-1. In the Firebase Console, navigate to **Authentication** → **Sign-in method** (sidebar)
-2. Click **Add new provider** → select **Google**
-3. Toggle **Enable** to ON
-4. Enter a **Project support email** (your Google account email)
-5. Click **Save**
+Instead, follow these steps to provide your credentials to Terraform:
+
+1. Complete **Step 4** to create an OAuth 2.0 client in the GCP Console
+   and obtain a **Client ID** and **Client Secret**.
+2. Complete **Step 5** to fill in the `google_idp_client_id` and
+   `google_idp_client_secret` fields in `terraform.tfvars`.
+3. When you run `terraform apply` (Step 7), Terraform will automatically
+   create and enable the Google sign-in provider using those credentials.
+
+!!! warning "Manual Conflict"
+    Enabling Google sign-in manually in the Firebase Console **before**
+    `terraform apply` will cause Terraform to fail with a resource-already-exists
+    error. If you've already done this, see the import instructions in
+    Step 7.3 and how to fix.
 
 See [Google Sign-In with Firebase](https://firebase.google.com/docs/auth/web/google-signin) for more information.
 
-### 3.3 Register a Web Application
+### 2.3 Register a Web Application
 
 1. In the Firebase Console, go to **Project settings** (gear icon) → **General** tab
 2. Scroll to **Your apps** → click the **Web** icon (`</>`)
@@ -156,6 +141,32 @@ See [Google Sign-In with Firebase](https://firebase.google.com/docs/auth/web/goo
     Use the **same Google email** for both your Firebase project and GCP Console. Mixing accounts can cause permission conflicts when Terraform provisions Identity Platform resources.
 
 ---
+
+## Step 3: Configure Environment Variables
+
+1. Clone the repository and change to the project root:
+   ```bash
+   git clone https://github.com/your-org/skewer.git
+   cd skewer
+   ```
+
+2. Copy the example file:
+   ```bash
+   cp apps/scene-previewer/.env.example apps/scene-previewer/.env
+   ```
+
+3. Open `apps/scene-previewer/.env` and fill in the values from Steps 2 and 7:
+
+   ```
+   VITE_API_URL=https://skewer-api-XXXXX.REGION.run.app         # filled in after Step 7
+   VITE_FIREBASE_API_KEY=your_api_key                           # from Step 2.3
+   VITE_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com    # from Step 2.3
+   ```
+
+!!! note "API URL"
+    `VITE_API_URL` will be set after Terraform finishes deploying — the Cloud Run API URL is printed in the Terraform output as `api_url`.
+
+---  
 
 ## Step 4: Create an OAuth 2.0 Client in GCP Console
 
@@ -270,18 +281,43 @@ See [Bucket naming requirements](https://cloud.google.com/storage/docs/naming-bu
 
 ### 7.1 Update the Backend Configuration
 
-Open `deployments/terraform/main.tf` and update the `backend` block with your bucket name:
+You will need update `backend` with your bucket configuration. Start by copying the backend example and edit the bucket name.
 
-```hcl
-terraform {
-  backend "gcs" {
-    bucket = "YOUR_PROJECT_ID-tfstate"   # replace with your bucket name
-    prefix = "skewer"
-  }
-}
+```sh
+cp deployments/terraform/backend.example.hcl deployments/terraform/backend.hcl
 ```
 
-See the [Terraform GCS backend documentation](https://developer.hashicorp.com/terraform/language/settings/backends/gcs) for details.
+Use a bucket tied to your project, for example:
+
+```hcl
+bucket = "YOUR_PROJECT_ID-tfstate"
+prefix = "skewer"
+```
+
+!!! note "Prefix"
+    The prefix will prepend all principals across the workflow (IAM names, VPCs, bucket items, etc.)
+
+The bucket must exist before Terraform can initialize the backend. Then run:
+
+```sh
+terraform init -backend-config=backend.hcl
+```
+
+If this checkout was already initialized against a different backend, use:
+
+```sh
+terraform init -reconfigure -backend-config=backend.hcl
+```
+
+If you intentionally want to move existing state into your new bucket, use
+`-migrate-state` instead of `-reconfigure` and review Terraform's migration
+prompt carefully.
+
+!!! note "Contributing"
+    Keep `backend.hcl` and `terraform.tfvars` uncommitted. Commit only the shared
+    Terraform modules and example files.
+
+See the [Terraform GCS backend documentation](https://developer.hashicorp.com/terraform/language/settings/backends/gcs) for more details.
 
 ### 7.2 Initialize and Apply
 
@@ -329,6 +365,7 @@ api_url = "https://skewer-api-XXXXX.REGION.run.app"
     Firebase: Error (auth/operation-not-allowed)
     ```
     The Google identity provider was not created. This happens if `google_idp_client_id` and `google_idp_client_secret` were not set in `terraform.tfvars`. Fix it by:
+
     1. Adding the correct values to `terraform.tfvars`
     2. Running `terraform apply` again
 
@@ -368,17 +405,21 @@ See [GCS lifecycle management](https://cloud.google.com/storage/docs/lifecycle) 
 
 ---
 
-## Step 8: Build and Push Docker Images (Optional)
+## Step 8: Build and Push Docker Images
 
-The CI/CD pipeline automatically builds and pushes images when you push to the `main` branch via a Cloud Build trigger. However, if this is a fresh project and no images exist yet, you can build them manually:
+Sinc this is a fresh project and no images exist for it yet, you can build them manually. Assuming you are still in the terraform folder, run this command:
 
 ```bash
 gcloud auth login
 gcloud config set project YOUR_PROJECT_ID
 
+REGION="YOUR_TERRAFORM_REGION"
+SERVICE_ACCOUNT=$(terraform output -raw cloudbuild_service_account_email)
+
 gcloud builds submit \
-  --config deployments/cloudbuild.yaml \
-  --substitutions _AR_BASE="us-west2-docker.pkg.dev/YOUR_PROJECT_ID/skewer"
+  --config ../cloudbuild.yaml \
+  --service-account "projects/YOUR_PROJECT_ID/serviceAccounts/${SERVICE_ACCOUNT}" \
+  --substitutions _REGION="$REGION",_AR_BASE="$REGION-docker.pkg.dev/YOUR_PROJECT_ID/skewer"
 ```
 
 ---
@@ -387,7 +428,7 @@ gcloud builds submit \
 
 ### From the Previewer
 
-Run the previewer locally:
+Navigate to the project root. From there go to `apps/scene-previewer` and run the previewer locally using bun:
 
 ```bash
 bun install

--- a/docs/getting-started/gcp.md
+++ b/docs/getting-started/gcp.md
@@ -101,7 +101,7 @@ The scene previewer uses Firebase Authentication for Google sign-in. This lets u
 
 1. Open the [Firebase Console](https://console.firebase.google.com/)
 2. Click **Add project**
-3. Select your **existing GCP project** from the dropdown (the one created in Step 1)
+3. Select your **existing GCP project** from the dropdown (the one created in [Step 1](#step-1-create-a-google-cloud-project))
 4. Follow the prompts to complete setup (you can leave Analytics disabled)
 
 See [Add Firebase to your project](https://firebase.google.com/docs/projects/learn-more#add-resources-existing-gcp) for details.
@@ -111,18 +111,18 @@ You do **not** need to manually add or enable the **Google** sign-in provider in
 
 Instead, follow these steps to provide your credentials to Terraform:
 
-1. Complete **Step 4** to create an OAuth 2.0 client in the GCP Console
+1. Complete [**Step 4**](#step-4-create-an-oauth-20-client-in-gcp-console) to create an OAuth 2.0 client in the GCP Console
    and obtain a **Client ID** and **Client Secret**.
-2. Complete **Step 5** to fill in the `google_idp_client_id` and
+2. Complete [**Step 5**](#step-5-configure-terraformtfvars) to fill in the `google_idp_client_id` and
    `google_idp_client_secret` fields in `terraform.tfvars`.
-3. When you run `terraform apply` (Step 7), Terraform will automatically
+3. When you run `terraform apply` ([Step 7](#step-7-deploy-infrastructure-with-terraform)), Terraform will automatically
    create and enable the Google sign-in provider using those credentials.
 
 !!! warning "Manual Conflict"
     Enabling Google sign-in manually in the Firebase Console **before**
     `terraform apply` will cause Terraform to fail with a resource-already-exists
     error. If you've already done this, see the import instructions in
-    Step 7.3 and how to fix.
+    [Step 7.3](#73-note-the-api-url) and how to fix.
 
 See [Google Sign-In with Firebase](https://firebase.google.com/docs/auth/web/google-signin) for more information.
 
@@ -146,7 +146,7 @@ See [Google Sign-In with Firebase](https://firebase.google.com/docs/auth/web/goo
 
 1. Clone the repository and change to the project root:
    ```bash
-   git clone https://github.com/your-org/skewer.git
+   git clone https://github.com/skewer-project/skewer.git
    cd skewer
    ```
 
@@ -155,12 +155,12 @@ See [Google Sign-In with Firebase](https://firebase.google.com/docs/auth/web/goo
    cp apps/scene-previewer/.env.example apps/scene-previewer/.env
    ```
 
-3. Open `apps/scene-previewer/.env` and fill in the values from Steps 2 and 7:
+3. Open `apps/scene-previewer/.env` and fill in the values from [Step 2](#step-2-set-up-firebase-authentication) and [Step 7](#step-7-deploy-infrastructure-with-terraform):
 
    ```
-   VITE_API_URL=https://skewer-api-XXXXX.REGION.run.app         # filled in after Step 7
-   VITE_FIREBASE_API_KEY=your_api_key                           # from Step 2.3
-   VITE_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com    # from Step 2.3
+   VITE_API_URL=https://skewer-api-XXXXX.REGION.run.app         # filled in after [Step 7](#step-7-deploy-infrastructure-with-terraform)
+   VITE_FIREBASE_API_KEY=your_api_key                           # from [Step 2.3](#23-register-a-web-application)
+   VITE_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com    # from [Step 2.3](#23-register-a-web-application)
    ```
 
 !!! note "API URL"
@@ -197,7 +197,7 @@ Firebase needs an OAuth 2.0 Client ID to authenticate users via Google. This lin
      ```
    - Click **Create**
 
-5. After creation, copy the **Client ID** and **Client Secret** — you'll need them in Step 5.
+5. After creation, copy the **Client ID** and **Client Secret** — you'll need them in [Step 5](#step-5-configure-terraformtfvars).
 
 !!! danger "Project ID Required"
     Replace `YOUR_PROJECT_ID` with your **actual GCP project ID** (not the project number or Firebase app name). These can differ. You can find your project ID in the [GCP Console project selector](https://console.cloud.google.com/projectselector2/home/dashboard).
@@ -249,8 +249,8 @@ Terraform variables control your deployment configuration.
    
    admin_emails = ["your-email@gmail.com"]   # Emails authorized to use the previewer
    
-   google_idp_client_id     = "YOUR_CLIENT_ID"      # From Step 4
-   google_idp_client_secret = "YOUR_CLIENT_SECRET"  # From Step 4
+   google_idp_client_id     = "YOUR_CLIENT_ID"      # From [Step 4](#step-4-create-an-oauth-20-client-in-gcp-console)
+   google_idp_client_secret = "YOUR_CLIENT_SECRET"  # From [Step 4](#step-4-create-an-oauth-20-client-in-gcp-console)
    ```
 
    Other fields can be left at their defaults. They control worker machine types, CPU/memory allocation, retry counts, and data retention policies.
@@ -281,7 +281,7 @@ See [Bucket naming requirements](https://cloud.google.com/storage/docs/naming-bu
 
 ### 7.1 Update the Backend Configuration
 
-You will need update `backend` with your bucket configuration. Start by copying the backend example and edit the bucket name.
+You will need to update the `backend` with your bucket configuration. Start by copying the backend example and edit the bucket name.
 
 ```sh
 cp deployments/terraform/backend.example.hcl deployments/terraform/backend.hcl
@@ -345,7 +345,7 @@ After `terraform apply` completes, look for this line in the output:
 api_url = "https://skewer-api-XXXXX.REGION.run.app"
 ```
 
-**Copy this URL** — you'll need it for `.env` in Step 2.
+**Copy this URL** — you'll need it for `.env` in [Step 3](#step-3-configure-environment-variables).
 
 !!! important "Identity Platform Already Enabled"
     If `terraform apply` fails with:
@@ -399,7 +399,7 @@ flowchart TD
 
 - **Data Bucket**: Scene uploads, rendered layer frames (EXR), and final composited PNGs. Lifecycle rules auto-delete old renders after 30 days.
 - **Cache Bucket**: Layer cache manifests. If a layer's content hasn't changed, the workflow skips rendering and reuses cached output. Lifecycle rules auto-delete after 90 days.
-- **TFState Bucket**: Terraform remote state and locking. Created manually in Step 6.
+- **TFState Bucket**: Terraform remote state and locking. Created manually in [Step 6](#step-6-create-a-terraform-state-bucket).
 
 See [GCS lifecycle management](https://cloud.google.com/storage/docs/lifecycle) for details on automatic cleanup.
 
@@ -407,7 +407,9 @@ See [GCS lifecycle management](https://cloud.google.com/storage/docs/lifecycle) 
 
 ## Step 8: Build and Push Docker Images
 
-Sinc this is a fresh project and no images exist for it yet, you can build them manually. Assuming you are still in the terraform folder, run this command:
+Since this is a fresh project and no images exist for it yet, you can build them manually from your local checkout. This uses `cloudbuild_from_local.yaml`, which skips the LFS fetch step (`cloudbuild.yaml` is reserved for the automated trigger that does a fresh git checkout and needs it).
+
+Assuming you are still in the `deployments/terraform` directory, run:
 
 ```bash
 gcloud auth login
@@ -417,10 +419,17 @@ REGION="YOUR_TERRAFORM_REGION"
 SERVICE_ACCOUNT=$(terraform output -raw cloudbuild_service_account_email)
 
 gcloud builds submit \
-  --config ../cloudbuild.yaml \
+  --config ../cloudbuild_from_local.yaml \
   --service-account "projects/YOUR_PROJECT_ID/serviceAccounts/${SERVICE_ACCOUNT}" \
   --substitutions _REGION="$REGION",_AR_BASE="$REGION-docker.pkg.dev/YOUR_PROJECT_ID/skewer"
 ```
+
+!!! note "git LFS"
+    The C++ skewer worker build needs one LFS-tracked file: `skewer/external/srgb_spec_data.h`. The rest of the LFS files (test assets, golden images, sample volumes) are only needed for development and testing — not for deploying your own render farm. Navigate to the project root and pull just what you need:
+
+    ```bash
+    git lfs pull --include="skewer/external/srgb_spec_data.h"
+    ```
 
 ---
 
@@ -459,11 +468,12 @@ After submitting, click the cloud icon in the top-right corner of the previewer 
 *Navigating the scene previewer with a loaded scene. Layers, objects, and materials appear in the sidebar.*
 
 The cloud workflow orchestrates the process:
+
 1. All layers render in parallel on separate Cloud Batch VMs
 2. After all layers complete, a Loom compositing job merges them
 3. The final composite is written to the output directory
 
-Refresh the tracker periodically to see updated status. If a layer fails, the tracker shows the error — check the troubleshooting section below.
+Refresh the tracker periodically to see updated status. If a layer fails, the tracker shows the error — check the [troubleshooting section](#troubleshooting-common-issues) below.
 
 ### View the Result
 
@@ -535,6 +545,7 @@ Skewer render workers use **SPOT instances** by default (`provisioningModel: "SP
 #### `Firebase: Error (auth/operation-not-allowed)`
 
 The Google identity provider is not properly configured. Fix:
+
 1. Verify `google_idp_client_id` and `google_idp_client_secret` are set correctly in `terraform.tfvars`
 2. Run `terraform apply` again
 3. Alternatively, enable Google sign-in manually in [Firebase Console → Authentication → Sign-in method](https://console.firebase.google.com/project/_/authentication/providers)
@@ -542,6 +553,7 @@ The Google identity provider is not properly configured. Fix:
 #### `The request was not authenticated` (401)
 
 The previewer isn't sending a valid Firebase ID token. Fix:
+
 1. Sign out and sign back in to refresh the auth token
 2. Verify `VITE_FIREBASE_API_KEY` and `VITE_FIREBASE_AUTH_DOMAIN` are correct in `.env`
 3. Check browser DevTools Console for auth errors

--- a/docs/getting-started/gcp.md
+++ b/docs/getting-started/gcp.md
@@ -307,7 +307,7 @@ After `terraform apply` completes, look for this line in the output:
 api_url = "https://skewer-api-XXXXX.REGION.run.app"
 ```
 
-**Copy this URL** — you'll need it for `.env` in Step 3.
+**Copy this URL** — you'll need it for `.env` in Step 2.
 
 !!! important "Identity Platform Already Enabled"
     If `terraform apply` fails with:

--- a/docs/getting-started/gcp.md
+++ b/docs/getting-started/gcp.md
@@ -56,135 +56,328 @@ flowchart LR
     class CLI,Previewer user
 ```
 
+The pipeline orchestrates parallel layer rendering via Cloud Batch, writes frames to GCS, then composites all layers into final PNG images. The previewer uploads scene assets, triggers the pipeline, and polls for completion.
+
+---
+
 ## Prerequisites
 
-Before you begin, you'll need:
+Install the following tools before beginning:
 
-1. A **Google Cloud Project** with billing enabled ([free credits available](https://cloud.google.com/free))
-2. A **GitHub account** (for the initial repo clone)
-3. The following tools installed locally:
-   - [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) (`gcloud`)
-   - [Terraform](https://developer.hashicorp.com/terraform/downloads) (v1.5+)
-   - [Git](https://git-scm.com/downloads)
+| Tool                                                                     | Minimum Version | Install Guide                                                                  |
+| ------------------------------------------------------------------------ | --------------- | ------------------------------------------------------------------------------ |
+| [Google Cloud SDK (`gcloud`)](https://cloud.google.com/sdk/docs/install) | latest          | [Install guide](https://cloud.google.com/sdk/docs/install)                     |
+| [Terraform](https://developer.hashicorp.com/terraform/install)           | >= 1.6          | [Install guide](https://developer.hashicorp.com/terraform/install)             |
+| [Bun](https://bun.sh/docs/installation)                                  | latest          | [Install guide](https://bun.sh/docs/installation)                              |
+| [Git](https://git-scm.com/)                                              | latest          | [Install guide](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) |
 
-## 1. Clone the Repository
+!!! note "Authentication"
+    After installing `gcloud`, authenticate and set your project:
+    ```bash
+    gcloud auth login
+    gcloud config set project YOUR_PROJECT_ID
+    ```
 
-```bash
-git clone https://github.com/skewer-project/skewer
-cd skewer
+---
+
+## Step 1: Create a Google Cloud Project
+
+1. Open the [GCP Console](https://console.cloud.google.com/)
+2. Click the project dropdown at the top of the page → **New Project**
+3. Enter a project name (e.g., `skewer-render-farm`)
+4. Note the **Project ID** — you'll need it throughout this guide
+5. Click **Create**
+
+!!! important "Billing Required"
+    Ensure billing is enabled on your project. Go to [Billing](https://console.cloud.google.com/billing) and link a billing account. Education accounts (Google Cloud for Education) include credits that cover typical rendering workloads.
+
+---
+
+## Step 2: Configure Environment Variables
+
+1. Copy the example file:
+   ```bash
+   cp apps/scene-previewer/.env.example apps/scene-previewer/.env
+   ```
+
+2. Open `apps/scene-previewer/.env` and fill in the values from Step 2:
+   ```
+   VITE_API_URL=https://skewer-api-XXXXX.REGION.run.app         # filled in after Step 7
+   VITE_FIREBASE_API_KEY=your_api_key                           # from Step 3.3
+   VITE_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com    # from Step 3.3
+   ```
+
+!!! note "API URL"
+    `VITE_API_URL` will be set after Terraform finishes deploying — the Cloud Run API URL is printed in the Terraform output as `api_url`.
+
+---
+
+## Step 3: Set Up Firebase Authentication
+
+The scene previewer uses Firebase Authentication for Google sign-in. This lets users authenticate with their Google account and obtain an ID token that the Skewer API verifies.
+
+### 3.1 Create a Firebase Project
+
+1. Open the [Firebase Console](https://console.firebase.google.com/)
+2. Click **Add project**
+3. Select your **existing GCP project** from the dropdown (the one created in Step 1)
+4. Follow the prompts to complete setup (you can leave Analytics disabled)
+
+See [Add Firebase to your project](https://firebase.google.com/docs/projects/learn-more#add-resources-existing-gcp) for details.
+
+### 3.2 Enable Google Sign-In
+
+1. In the Firebase Console, navigate to **Authentication** → **Sign-in method** (sidebar)
+2. Click **Add new provider** → select **Google**
+3. Toggle **Enable** to ON
+4. Enter a **Project support email** (your Google account email)
+5. Click **Save**
+
+See [Google Sign-In with Firebase](https://firebase.google.com/docs/auth/web/google-signin) for more information.
+
+### 3.3 Register a Web Application
+
+1. In the Firebase Console, go to **Project settings** (gear icon) → **General** tab
+2. Scroll to **Your apps** → click the **Web** icon (`</>`)
+3. Enter an app nickname (e.g., `skewer-preview`)
+4. Click **Register app**
+5. Copy the following values from the Firebase SDK config:
+   - **API Key** → use as `VITE_FIREBASE_API_KEY`
+   - **Auth Domain** → use as `VITE_FIREBASE_AUTH_DOMAIN` (format: `your-project-id.firebaseapp.com`)
+6. Click **Continue to console**
+
+!!! danger "Account Conflict"
+    Use the **same Google email** for both your Firebase project and GCP Console. Mixing accounts can cause permission conflicts when Terraform provisions Identity Platform resources.
+
+---
+
+## Step 4: Create an OAuth 2.0 Client in GCP Console
+
+Firebase needs an OAuth 2.0 Client ID to authenticate users via Google. This links your Firebase project to your GCP project.
+
+1. Open [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials) in the GCP Console
+2. Click **+ Create Credentials** → **OAuth client ID**
+3. If prompted, configure the OAuth consent screen:
+   - User Type: **Internal**
+   - App name: `Skewer Previewer` (or any name)
+   - User support email: your email
+   - Developer contact email: your email
+   - Click **Save and Continue** through the remaining screens
+4. For the OAuth client:
+   - Application type: **Web application**
+   - Name: `web client` (or any name)
+   - **Authorized JavaScript origins** — add these three URIs:
+     ```
+     http://localhost
+     http://localhost:5173
+     https://YOUR_PROJECT_ID.firebaseapp.com
+     ```
+   - **Authorized redirect URIs** — add this URI:
+     ```
+     https://YOUR_PROJECT_ID.firebaseapp.com/__/auth/handler
+     ```
+   - Click **Create**
+
+5. After creation, copy the **Client ID** and **Client Secret** — you'll need them in Step 5.
+
+!!! danger "Project ID Required"
+    Replace `YOUR_PROJECT_ID` with your **actual GCP project ID** (not the project number or Firebase app name). These can differ. You can find your project ID in the [GCP Console project selector](https://console.cloud.google.com/projectselector2/home/dashboard).
+
+See [Create an OAuth 2.0 Client ID](https://developers.google.com/identity/protocols/oauth2#1.-obtain-oauth-2.0-credentials-from-the-dynamicdata.setvar.console_name-.) for full documentation.
+
+### How Authentication Works
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User (Browser)
+    participant P as Previewer (React App)
+    participant F as Firebase Auth
+    participant G as Google OAuth
+    participant A as skewer-api (Cloud Run)
+
+    U->>P: Open previewer
+    P->>F: Init Google sign-in
+    F->>G: Redirect to Google login
+    G-->>F: OAuth callback with code
+    F-->>P: Firebase ID Token
+    P->>A: POST /v1/jobs/init + Bearer Token
+    A->>A: Verify token & check admin_emails
+    A-->>P: Signed GCS upload URLs
+    P->>GCS: PUT scene assets (concurrent)
+    P->>A: POST /v1/jobs/{id}/submit
+    A->>A: Trigger Cloud Workflows
 ```
 
-## 2. Enable Required APIs
+When a user signs in, Firebase handles the Google OAuth flow and returns an ID token. The previewer sends this token with every API request. The `skewer-api` service verifies the token and checks that the user's email is in `admin_emails` before allowing any actions.
 
-Enable the services used by Skewer:
+---
 
-```bash
-gcloud services enable \
-    cloudresourcemanager.googleapis.com \
-    run.googleapis.com \
-    workflows.googleapis.com \
-    batch.googleapis.com \
-    storage.googleapis.com \
-    artifactregistry.googleapis.com \
-    firebase.googleapis.com \
-    compute.googleapis.com \
-    iamcredentials.googleapis.com \
-    cloudbuild.googleapis.com
+## Step 5: Configure `terraform.tfvars`
+
+Terraform variables control your deployment configuration.
+
+1. Copy the sample file:
+   ```bash
+   cp deployments/terraform/terraform.tfvars.sample deployments/terraform/terraform.tfvars
+   ```
+
+2. Open `deployments/terraform/terraform.tfvars` and fill in the required fields (marked with `# CHANGE`):
+
+   ```hcl
+   project_id  = "YOUR_GCP_PROJECT_ID"       # Your GCP project ID
+   region      = "us-west2"                  # Your preferred GCP region
+   
+   admin_emails = ["your-email@gmail.com"]   # Emails authorized to use the previewer
+   
+   google_idp_client_id     = "YOUR_CLIENT_ID"      # From Step 4
+   google_idp_client_secret = "YOUR_CLIENT_SECRET"  # From Step 4
+   ```
+
+   Other fields can be left at their defaults. They control worker machine types, CPU/memory allocation, retry counts, and data retention policies.
+
+!!! warning "Admin Emails Required"
+    The `admin_emails` field controls who can submit renders from the previewer. **Include your Google account email**, or you will be denied access when trying to render. Add additional emails for team members who need render access.
+
+---
+
+## Step 6: Create a Terraform State Bucket
+
+Terraform stores its state in a GCS bucket. This must be created manually before running `terraform init`.
+
+1. Open [Cloud Storage → Buckets](https://console.cloud.google.com/storage/browser) in the GCP Console
+2. Click **+ Create**
+3. Name the bucket: `YOUR_PROJECT_ID-tfstate` (e.g., `skewer-render-farm-tfstate`)
+4. Leave all other settings at default
+5. Click **Create**
+
+!!! danger "Globally Unique Bucket Name"
+    GCS bucket names must be **globally unique** across all GCP users. Using `YOUR_PROJECT_ID-tfstate` is recommended since project IDs are unique.
+
+See [Bucket naming requirements](https://cloud.google.com/storage/docs/naming-buckets) for details.
+
+---
+
+## Step 7: Deploy Infrastructure with Terraform
+
+### 7.1 Update the Backend Configuration
+
+Open `deployments/terraform/main.tf` and update the `backend` block with your bucket name:
+
+```hcl
+terraform {
+  backend "gcs" {
+    bucket = "YOUR_PROJECT_ID-tfstate"   # replace with your bucket name
+    prefix = "skewer"
+  }
+}
 ```
 
-## 3. Create a Terraform Variable File
+See the [Terraform GCS backend documentation](https://developer.hashicorp.com/terraform/language/settings/backends/gcs) for details.
+
+### 7.2 Initialize and Apply
 
 ```bash
 cd deployments/terraform
-cp terraform.tfvars.example terraform.tfvars
-```
-
-Edit `terraform.tfvars` with your project details:
-
-```hcl
-# Required: Your GCP project ID
-project_id = "skewer-xxxxx"
-
-# Required: Billing account ID
-billing_account = "XXXXXX-XXXXXX-XXXXXX"
-
-# Required: Admin email addresses for the API
-admin_emails = ["your.email@gmail.com"]
-
-# Optional: Firebase Identity Platform config
-firebase_project_id = "skewer-xxxxx"
-google_idp_client_id = ""
-google_idp_client_secret = ""
-
-# Optional: Override defaults
-region = "us-west1"
-machine_type = "n2d-highcpu-8"
-```
-
-## 4. Apply Terraform
-
-```bash
 terraform init
 terraform apply
 ```
 
-This provisions:
+This will provision:
 
-- **Cloud Run** service for the API/Coordinator
-- **Cloud Workflows** definition for the render pipeline
-- **Cloud Batch** configuration for workers
-- **GCS Buckets** for data and cache storage
-- **Artifact Registry** repository for worker images
-- **Firebase** project for authentication
-- **IAM** roles and service accounts
+   - VPC network and subnets
+   - Cloud Run services (`skewer-api`, `skewer-coordinator`)
+   - Cloud Workflows pipeline (`skewer-render-pipeline`)
+   - Artifact Registry repository
+   - GCS buckets for data and caching
+   - IAM service accounts and roles
+   - Identity Platform configuration
 
-The initial apply takes approximately **5–10 minutes**.
+### 7.3 Note the API URL
 
-## 5. Build and Push Worker Images
+After `terraform apply` completes, look for this line in the output:
+
+```
+api_url = "https://skewer-api-XXXXX.REGION.run.app"
+```
+
+**Copy this URL** — you'll need it for `.env` in Step 3.
+
+!!! important "Identity Platform Already Enabled"
+    If `terraform apply` fails with:
+    ```
+    Error: Error creating Config: googleapi: Error 400: INVALID_PROJECT_ID : Identity Platform has already been enabled for this project.
+    ```
+    This means Identity Platform was enabled manually (via Firebase Console) before Terraform ran. Fix it by importing the existing resource:
+    ```bash
+    terraform import 'google_identity_platform_config.default' 'YOUR_PROJECT_ID'
+    terraform apply
+    ```
+    See [Terraform Import](https://developer.hashicorp.com/terraform/cli/import) for details.
+
+!!! important "Google Identity Provider Not Created"
+    If you see this error after `terraform apply`:
+    ```
+    Firebase: Error (auth/operation-not-allowed)
+    ```
+    The Google identity provider was not created. This happens if `google_idp_client_id` and `google_idp_client_secret` were not set in `terraform.tfvars`. Fix it by:
+    1. Adding the correct values to `terraform.tfvars`
+    2. Running `terraform apply` again
+
+### GCS Bucket Layout
+
+After deployment, your project will have several GCS buckets. Here's how they're used:
+
+```mermaid
+flowchart TD
+    subgraph TFState["Terraform State Bucket"]
+        TFStateDir["{PROJECT-ID}-tfstate\nStores: Terraform state lock files"]
+    end
+
+    subgraph Data["Data Bucket (skewer-data-dev)"]
+        direction TB
+        Uploads["uploads/{pipeline-id}/\nscene.json, layer-*.json, *.obj, textures"]
+        Renders["renders/{pipeline-id}/\nlayer-mercury/frame-*.exr\nlayer-venus/frame-*.exr\n..."]
+        Composites["composites/{pipeline-id}/\nframe-0001.png\nframe-0002.png\n..."]
+    end
+
+    subgraph Cache["Cache Bucket (skewer-cache-dev)"]
+        CacheLayers["{layer-hash}/\nCache manifest files for\nskipping unchanged layers"]
+    end
+
+    Uploads -->|workflow creates batch jobs| Renders
+    Renders -->|loom composites all layers| Composites
+    
+    classDef bucket fill:#e8eaf6,stroke:#5c6bc0,color:#1a1a2e,stroke-width:2px
+    class TFState,Data,Cache bucket
+```
+
+- **Data Bucket**: Scene uploads, rendered layer frames (EXR), and final composited PNGs. Lifecycle rules auto-delete old renders after 30 days.
+- **Cache Bucket**: Layer cache manifests. If a layer's content hasn't changed, the workflow skips rendering and reuses cached output. Lifecycle rules auto-delete after 90 days.
+- **TFState Bucket**: Terraform remote state and locking. Created manually in Step 6.
+
+See [GCS lifecycle management](https://cloud.google.com/storage/docs/lifecycle) for details on automatic cleanup.
+
+---
+
+## Step 8: Build and Push Docker Images (Optional)
+
+The CI/CD pipeline automatically builds and pushes images when you push to the `main` branch via a Cloud Build trigger. However, if this is a fresh project and no images exist yet, you can build them manually:
 
 ```bash
-# Build and push the Skewer renderer worker image
-gcloud builds submit --config cloudbuild.yaml
+gcloud auth login
+gcloud config set project YOUR_PROJECT_ID
 
-# Verify the image was pushed
-gcloud artifacts docker images list \
-  --repository=us-west1-docker.pkg.dev/$PROJECT_ID/skewer-workers
+gcloud builds submit \
+  --config deployments/cloudbuild.yaml \
+  --substitutions _AR_BASE="us-west2-docker.pkg.dev/YOUR_PROJECT_ID/skewer"
 ```
 
-## 6. Configure Firebase Authentication
+---
 
-1. Open the [Firebase Console](https://console.firebase.google.com/)
-2. Select your project
-3. Go to **Authentication → Sign-in method**
-4. Enable **Google** as a sign-in provider
-5. Copy the **Web client ID** and **Web client secret**
-6. Update your `terraform.tfvars`:
+## Step 9: Render Your First Scene
 
-```hcl
-google_idp_client_id = "xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com"
-google_idp_client_secret = "GOCSPX-xxxxxxxxxxxxxxxxxxxxx"
-```
-
-7. Re-apply Terraform:
-
-```bash
-terraform apply
-```
-
-## 7. Deploy the Previewer
-
-Create a `.env` file in `apps/scene-previewer/`:
-
-```bash
-cd apps/scene-previewer
-
-cat > .env << EOF
-VITE_API_URL=https://skewer-api-xxxxx-uc.a.run.app
-VITE_FIREBASE_API_KEY=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-VITE_FIREBASE_AUTH_DOMAIN=skewer-xxxxx.firebaseapp.com
-VITE_FIREBASE_PROJECT_ID=skewer-xxxxx
-EOF
-```
+### From the Previewer
 
 Run the previewer locally:
 
@@ -192,10 +385,6 @@ Run the previewer locally:
 bun install
 bun run dev
 ```
-
-## 8. Render Your First Scene
-
-### From the Previewer
 
 1. Open http://localhost:5173
 2. Sign in with Google

--- a/docs/legacy/deep_compositing.md
+++ b/docs/legacy/deep_compositing.md
@@ -15,7 +15,7 @@ ightarrow 15)$
 *   **Events:** $\{10, 15, 20\}$
 
 ### Step 2: Interval Generation
-Using the sorted "event" list from Step 1, you create a set of discrete, non-overlapping depth segments. Each pair of adjacent events forms a new interval:
+Using the sorted "event" list from [Step 1](#step-1-boundary-collection-interleaving), you create a set of discrete, non-overlapping depth segments. Each pair of adjacent events forms a new interval:
 
 -   **Segment 1:** From Z = 10 to Z = 15 (The first part of the fog).
 -   **Segment 2:** At Z = 15 (A zero-thickness interval representing the solid object).


### PR DESCRIPTION
We accidentally removed some important documentation steps in #220 for `gcp.md`. This PR restores that.