### PR TITLE
[bugfix] limit integration tests ci parallelism

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       regen_goldens:
-        description: 'Regenerate golden image hashes instead of comparing'
+        description: "Regenerate golden image hashes instead of comparing"
         type: boolean
         default: false
 
@@ -85,7 +85,7 @@ jobs:
         run: ccache -z
 
       - name: Build
-        run: cmake --build --preset ci --parallel
+        run: cmake --build --preset ci --parallel 6
 
       - name: Run integration tests
         run: ./build/ci/tests/integration_tests


### PR DESCRIPTION
hopefully this stops integration tests from oom-ing