### PR TITLE
[feat] Add camera animation keyframes

### DIFF
--- a/apps/scene-previewer/src/App.tsx
+++ b/apps/scene-previewer/src/App.tsx
@@ -398,6 +398,19 @@ function App() {
 
 	const handleCameraHandleChange = useCallback(
 		(handle: CameraHandle, value: Vec3) => {
+			const keyframes = scene?.camera.keyframes;
+			if (
+				keyframes &&
+				keyframes.length > 0 &&
+				!keyframes.some(
+					(kf) => Math.abs(kf.time - currentTime) < CAMERA_KEYFRAME_TIME_EPS,
+				)
+			) {
+				console.warn(
+					"[App] Ignoring camera handle edit away from a camera keyframe.",
+				);
+				return;
+			}
 			handleSceneEdit((s) => {
 				const keyframes = s.camera.keyframes;
 				if (keyframes && keyframes.length > 0) {
@@ -424,7 +437,7 @@ function App() {
 				};
 			});
 		},
-		[handleSceneEdit, currentTime],
+		[handleSceneEdit, scene, currentTime],
 	);
 
 	const deleteSelectedObjectFromKeyboard = useEffectEvent(() => {

--- a/apps/scene-previewer/src/App.tsx
+++ b/apps/scene-previewer/src/App.tsx
@@ -48,6 +48,7 @@ import {
 import a from "./styles/App.module.css";
 import u from "./styles/shared/uiPrimitives.module.css";
 import type {
+	CameraHandle,
 	Material,
 	Medium,
 	RenderConfig,
@@ -103,6 +104,8 @@ function JobsCloudButton({ onClick }: { onClick: () => void }) {
 	);
 }
 
+const CAMERA_KEYFRAME_TIME_EPS = 1e-4;
+
 function App() {
 	const [scene, setScene] = useState<ResolvedScene | null>(null);
 	const [dirHandle, setDirHandle] = useState<FileSystemDirectoryHandle | null>(
@@ -118,6 +121,8 @@ function App() {
 	const [selectedMediumKey, setSelectedMediumKey] = useState<string | null>(
 		null,
 	);
+	const [selectedCameraHandle, setSelectedCameraHandle] =
+		useState<CameraHandle | null>(null);
 	const [transformMode, setTransformMode] = useState<
 		"translate" | "rotate" | "scale"
 	>("translate");
@@ -147,19 +152,31 @@ function App() {
 		setSelectedObjectKey(key);
 		setSelectedMaterialKey(null);
 		setSelectedMediumKey(null);
+		setSelectedCameraHandle(null);
 	}, []);
 
 	const handleSelectMaterial = useCallback((key: string | null) => {
 		setSelectedMaterialKey(key);
 		setSelectedObjectKey(null);
 		setSelectedMediumKey(null);
+		setSelectedCameraHandle(null);
 	}, []);
 
 	const handleSelectMedium = useCallback((key: string | null) => {
 		setSelectedMediumKey(key);
 		setSelectedObjectKey(null);
 		setSelectedMaterialKey(null);
+		setSelectedCameraHandle(null);
 	}, []);
+	const handleSelectCameraHandle = useCallback(
+		(handle: CameraHandle | null) => {
+			setSelectedCameraHandle(handle);
+			setSelectedObjectKey(null);
+			setSelectedMaterialKey(null);
+			setSelectedMediumKey(null);
+		},
+		[],
+	);
 	const [sceneVersion, setSceneVersion] = useState(0);
 	const [saving, setSaving] = useState(false);
 	const [showRenderDialog, setShowRenderDialog] = useState(false);
@@ -169,6 +186,14 @@ function App() {
 	const [isPlaying, setIsPlaying] = useState(false);
 	const viewportRef = useRef<ViewportHandle>(null);
 	const animRangeRef = useRef({ start: 0, end: 0 });
+	const selectedCameraHandleEditingEnabled = useMemo(() => {
+		if (!scene || !selectedCameraHandle) return true;
+		const keyframes = scene.camera.keyframes;
+		if (!keyframes || keyframes.length === 0) return true;
+		return keyframes.some(
+			(kf) => Math.abs(kf.time - currentTime) < CAMERA_KEYFRAME_TIME_EPS,
+		);
+	}, [scene, selectedCameraHandle, currentTime]);
 
 	function handleSceneLoaded(s: ResolvedScene, dir: FileSystemDirectoryHandle) {
 		setSceneSettings(s);
@@ -177,6 +202,7 @@ function App() {
 		setSelectedObjectKey(null);
 		setSelectedMaterialKey(null);
 		setSelectedMediumKey(null);
+		setSelectedCameraHandle(null);
 		setSceneVersion((v) => v + 1);
 		setHasUnsavedChanges(false);
 		setCurrentTime(0);
@@ -332,6 +358,37 @@ function App() {
 		[handleSceneEdit, scene, currentTime],
 	);
 
+	const handleCameraHandleChange = useCallback(
+		(handle: CameraHandle, value: Vec3) => {
+			handleSceneEdit((s) => {
+				const keyframes = s.camera.keyframes;
+				if (keyframes && keyframes.length > 0) {
+					const keyframeIndex = keyframes.findIndex(
+						(kf) => Math.abs(kf.time - currentTime) < CAMERA_KEYFRAME_TIME_EPS,
+					);
+					if (keyframeIndex < 0) return s;
+					return {
+						...s,
+						camera: {
+							...s.camera,
+							keyframes: keyframes.map((kf, i) =>
+								i === keyframeIndex ? { ...kf, [handle]: value } : kf,
+							),
+						},
+					};
+				}
+				return {
+					...s,
+					camera: {
+						...s.camera,
+						[handle]: value,
+					},
+				};
+			});
+		},
+		[handleSceneEdit, currentTime],
+	);
+
 	const deleteSelectedObjectFromKeyboard = useEffectEvent(() => {
 		if (!scene || !selectedObjectKey) return false;
 		handleDeleteObject(selectedObjectKey);
@@ -367,6 +424,7 @@ function App() {
 				setSelectedObjectKey(childKey);
 				setSelectedMaterialKey(null);
 				setSelectedMediumKey(null);
+				setSelectedCameraHandle(null);
 			}
 		},
 		[handleSceneEdit],
@@ -390,6 +448,7 @@ function App() {
 			setSelectedMaterialKey(`${tag}:${layerIdx}:mat:${name}`);
 			setSelectedObjectKey(null);
 			setSelectedMediumKey(null);
+			setSelectedCameraHandle(null);
 		},
 		[handleSceneEdit],
 	);
@@ -412,6 +471,7 @@ function App() {
 			setSelectedMediumKey(`${tag}:${layerIdx}:med:${name}`);
 			setSelectedObjectKey(null);
 			setSelectedMaterialKey(null);
+			setSelectedCameraHandle(null);
 		},
 		[handleSceneEdit],
 	);
@@ -447,6 +507,8 @@ function App() {
 		setDirHandle(null);
 		setSelectedObjectKey(null);
 		setSelectedMaterialKey(null);
+		setSelectedMediumKey(null);
+		setSelectedCameraHandle(null);
 		setHasUnsavedChanges(false);
 		setError("");
 	}
@@ -532,9 +594,13 @@ function App() {
 					isPlaying={isPlaying}
 					selectedObjectKey={selectedObjectKey}
 					onSelectObject={handleSelectObject}
+					selectedCameraHandle={selectedCameraHandle}
+					onSelectCameraHandle={handleSelectCameraHandle}
+					cameraHandleEditingEnabled={selectedCameraHandleEditingEnabled}
 					transformMode={transformMode}
 					transformSpace={transformSpace}
 					onTransformChange={handleTransformChange}
+					onCameraHandleChange={handleCameraHandleChange}
 				/>
 			</div>
 
@@ -657,9 +723,11 @@ function App() {
 							selectedObjectKey={selectedObjectKey}
 							selectedMaterialKey={selectedMaterialKey}
 							selectedMediumKey={selectedMediumKey}
+							selectedCameraHandle={selectedCameraHandle}
 							onSelectObject={handleSelectObject}
 							onSelectMaterial={handleSelectMaterial}
 							onSelectMedium={handleSelectMedium}
+							onSelectCameraHandle={handleSelectCameraHandle}
 							onAddGraphNode={handleAddGraphNode}
 							onAddMaterial={handleAddMaterial}
 							onAddMedium={handleAddMedium}

--- a/apps/scene-previewer/src/components/SceneInspector.module.css
+++ b/apps/scene-previewer/src/components/SceneInspector.module.css
@@ -6,6 +6,30 @@
 	margin-bottom: 2px;
 }
 
+.cameraHandleRow {
+	width: 100%;
+	margin: 0;
+	padding: 1px 4px;
+	border: 1px solid transparent;
+	border-radius: 4px;
+	background: transparent;
+	text-align: left;
+	font: inherit;
+	cursor: pointer;
+	transition:
+		background 0.12s,
+		border-color 0.12s;
+}
+
+.cameraHandleRow:hover {
+	background: rgba(255, 255, 255, 0.055);
+}
+
+.cameraHandleRowActive {
+	background: rgba(232, 165, 60, 0.12);
+	border-color: rgba(232, 165, 60, 0.34);
+}
+
 .sceneTreeSummary {
 	display: flex;
 	align-items: center;

--- a/apps/scene-previewer/src/components/SceneInspector.tsx
+++ b/apps/scene-previewer/src/components/SceneInspector.tsx
@@ -10,6 +10,7 @@ import { displayLabel, kindShort } from "../services/node-labels";
 import u from "../styles/shared/uiPrimitives.module.css";
 import type {
 	Camera,
+	CameraHandle,
 	Material,
 	Medium,
 	RenderConfig,
@@ -43,22 +44,43 @@ function ancestorOpenKeys(selectedKey: string | null): string[] {
 
 const CameraSection = memo(function CameraSection({
 	camera,
+	selectedCameraHandle,
+	onSelectCameraHandle,
 }: {
 	camera: Camera;
+	selectedCameraHandle: CameraHandle | null;
+	onSelectCameraHandle: (handle: CameraHandle | null) => void;
 }) {
+	const toggleHandle = (handle: CameraHandle) => {
+		onSelectCameraHandle(selectedCameraHandle === handle ? null : handle);
+	};
 	return (
 		<>
 			<div className={u.inspectorSectionHead}>Camera</div>
 			<div className={u.cameraBlock}>
 				<div className={u.kvTable}>
-					<div className={u.kvRow}>
+					<button
+						type="button"
+						className={`${u.kvRow} ${s.cameraHandleRow} ${
+							selectedCameraHandle === "look_from"
+								? s.cameraHandleRowActive
+								: ""
+						}`}
+						onClick={() => toggleHandle("look_from")}
+					>
 						<span className={u.kvKey}>from</span>
 						<span className={u.kvVal}>{vec3(camera.look_from)}</span>
-					</div>
-					<div className={u.kvRow}>
+					</button>
+					<button
+						type="button"
+						className={`${u.kvRow} ${s.cameraHandleRow} ${
+							selectedCameraHandle === "look_at" ? s.cameraHandleRowActive : ""
+						}`}
+						onClick={() => toggleHandle("look_at")}
+					>
 						<span className={u.kvKey}>at</span>
 						<span className={u.kvVal}>{vec3(camera.look_at)}</span>
-					</div>
+					</button>
 					<div className={u.kvRow}>
 						<span className={u.kvKey}>vup</span>
 						<span className={u.kvVal}>{vec3(camera.vup)}</span>
@@ -465,9 +487,11 @@ export function SceneInspector({
 	selectedObjectKey,
 	selectedMaterialKey,
 	selectedMediumKey,
+	selectedCameraHandle,
 	onSelectObject,
 	onSelectMaterial,
 	onSelectMedium,
+	onSelectCameraHandle,
 	onAddGraphNode,
 	onAddMaterial,
 	onAddMedium,
@@ -485,9 +509,11 @@ export function SceneInspector({
 	selectedObjectKey: string | null;
 	selectedMaterialKey: string | null;
 	selectedMediumKey: string | null;
+	selectedCameraHandle: CameraHandle | null;
 	onSelectObject: (key: string | null) => void;
 	onSelectMaterial: (key: string | null) => void;
 	onSelectMedium: (key: string | null) => void;
+	onSelectCameraHandle: (handle: CameraHandle | null) => void;
 	onAddGraphNode: (
 		tag: "ctx" | "lyr",
 		layerIdx: number,
@@ -518,7 +544,11 @@ export function SceneInspector({
 }) {
 	return (
 		<div className={s.inspectRoot}>
-			<CameraSection camera={scene.camera} />
+			<CameraSection
+				camera={scene.camera}
+				selectedCameraHandle={selectedCameraHandle}
+				onSelectCameraHandle={onSelectCameraHandle}
+			/>
 
 			<RenderSettingsPanel
 				settings={renderSettings}

--- a/apps/scene-previewer/src/components/Viewport.tsx
+++ b/apps/scene-previewer/src/components/Viewport.tsx
@@ -23,11 +23,7 @@ import {
 	makeThreeMaterial,
 	revokeBlobUrls,
 } from "../services/scene-to-three";
-import {
-	cameraHasKeyframes,
-	evaluateCameraAt,
-	evaluateTransformAt,
-} from "../services/transform";
+import { evaluateCameraAt, evaluateTransformAt } from "../services/transform";
 import type {
 	CameraHandle,
 	Material,
@@ -438,10 +434,6 @@ export function Viewport({
 		sceneVersion: number | null;
 	}>({ dirHandle: null, sceneVersion: null });
 
-	// Track previous dirHandle to distinguish a new scene load from a sceneVersion bump
-	const prevDirHandle = useRef<FileSystemDirectoryHandle | null | undefined>(
-		undefined,
-	);
 	const latestSceneRef = useRef(scene);
 	useEffect(() => {
 		latestSceneRef.current = scene;
@@ -829,17 +821,7 @@ export function Viewport({
 		if (!currentScene || !dirHandle) return;
 
 		const sc = threeScene.current;
-		const cam = camera.current;
-		const ctrl = controls.current;
-		if (!sc || !cam || !ctrl) return;
-
-		// Only reset the camera when a new scene is loaded (dirHandle changed),
-		// not on sceneVersion bumps — otherwise edits reset the viewport angle.
-		const isNewScene = dirHandle !== prevDirHandle.current;
-		prevDirHandle.current = dirHandle;
-		if (isNewScene) {
-			syncOrbitCameraToScene(cam, ctrl, currentScene, currentTimeRef.current);
-		}
+		if (!sc) return;
 
 		if (
 			lastBuild.current.dirHandle === dirHandle &&
@@ -1157,12 +1139,6 @@ export function Viewport({
 		const grp = sceneGroup.current;
 		const currentScene = scene;
 		if (!grp || !currentScene) return;
-
-		const cam = camera.current;
-		const ctrl = controls.current;
-		if (cam && ctrl && cameraHasKeyframes(currentScene.camera)) {
-			syncOrbitCameraToScene(cam, ctrl, currentScene, currentTime);
-		}
 
 		const proxy = gizmoProxy.current;
 		const isDragging = isDraggingRef.current;

--- a/apps/scene-previewer/src/components/Viewport.tsx
+++ b/apps/scene-previewer/src/components/Viewport.tsx
@@ -29,12 +29,17 @@ import {
 	evaluateTransformAt,
 } from "../services/transform";
 import type {
+	CameraHandle,
 	Material,
 	ResolvedScene,
 	StaticTransform,
 	Vec3,
 } from "../types/scene";
 import { isAnimated } from "../types/scene";
+
+const CAMERA_FROM_COLOR = 0x35d6ff;
+const CAMERA_AT_COLOR = 0xf0b34d;
+const CAMERA_SELECTED_COLOR = 0xffffff;
 
 /** Get the world-space center of an object — bbox center if it has geometry, otherwise origin. */
 function getWorldCenter(obj: THREE.Object3D, out: THREE.Vector3): void {
@@ -60,6 +65,173 @@ function syncOrbitCameraToScene(
 	cam.up.set(...c.vup);
 	cam.updateProjectionMatrix();
 	ctrl.update();
+}
+
+function makeCameraHandle(
+	name: CameraHandle,
+	color: number,
+	radius: number,
+): THREE.Mesh {
+	const mesh = new THREE.Mesh(
+		new THREE.SphereGeometry(radius, 18, 12),
+		new THREE.MeshBasicMaterial({
+			color,
+			depthTest: false,
+			transparent: true,
+			opacity: 0.95,
+		}),
+	);
+	mesh.name = `Camera ${name}`;
+	mesh.renderOrder = 4;
+	mesh.userData.cameraHandle = name;
+	return mesh;
+}
+
+function makeCameraLine(
+	name: string,
+	color: number,
+	opacity: number,
+): THREE.LineSegments {
+	const line = new THREE.LineSegments(
+		new THREE.BufferGeometry(),
+		new THREE.LineBasicMaterial({
+			color,
+			depthTest: false,
+			transparent: true,
+			opacity,
+		}),
+	);
+	line.name = name;
+	line.renderOrder = 3;
+	return line;
+}
+
+function createCameraRig(): THREE.Group {
+	const rig = new THREE.Group();
+	rig.name = "SceneCameraRig";
+	rig.userData.isCameraRig = true;
+
+	rig.add(makeCameraHandle("look_from", CAMERA_FROM_COLOR, 0.12));
+	rig.add(makeCameraHandle("look_at", CAMERA_AT_COLOR, 0.1));
+	rig.add(makeCameraLine("CameraAimLine", 0xe8f6ff, 0.78));
+	rig.add(makeCameraLine("CameraFrustum", CAMERA_FROM_COLOR, 0.62));
+	return rig;
+}
+
+function disposeCameraRig(rig: THREE.Group) {
+	rig.traverse((obj) => {
+		if (obj instanceof THREE.Mesh || obj instanceof THREE.LineSegments) {
+			obj.geometry?.dispose();
+			disposeMaterial(obj.material);
+		}
+	});
+}
+
+function lineByName(rig: THREE.Group, name: string): THREE.LineSegments | null {
+	const obj = rig.getObjectByName(name);
+	return obj instanceof THREE.LineSegments ? obj : null;
+}
+
+function handleByName(rig: THREE.Group, name: CameraHandle): THREE.Mesh | null {
+	const obj = rig.children.find(
+		(child) => child.userData.cameraHandle === name,
+	);
+	return obj instanceof THREE.Mesh ? obj : null;
+}
+
+function setLinePoints(line: THREE.LineSegments, points: THREE.Vector3[]) {
+	line.geometry.setFromPoints(points);
+	line.geometry.computeBoundingSphere();
+}
+
+function updateCameraRig(
+	rig: THREE.Group,
+	sceneData: ResolvedScene,
+	time: number,
+	aspect: number,
+	selectedHandle: CameraHandle | null,
+) {
+	const cam = evaluateCameraAt(sceneData.camera, time);
+	const lookFrom = new THREE.Vector3(...cam.look_from);
+	const lookAt = new THREE.Vector3(...cam.look_at);
+	const upHint = new THREE.Vector3(...cam.vup);
+	const forward = lookAt.clone().sub(lookFrom);
+	const planeDistance = Math.max(forward.length(), 0.001);
+	forward.normalize();
+	if (forward.lengthSq() < 1e-12) forward.set(0, 0, -1);
+
+	let right = new THREE.Vector3().crossVectors(forward, upHint).normalize();
+	if (right.lengthSq() < 1e-12) right = new THREE.Vector3(1, 0, 0);
+	const up = new THREE.Vector3().crossVectors(right, forward).normalize();
+
+	const halfHeight =
+		Math.tan(THREE.MathUtils.degToRad(cam.vfov) * 0.5) * planeDistance;
+	const halfWidth = halfHeight * aspect;
+	const center = lookFrom
+		.clone()
+		.add(forward.clone().multiplyScalar(planeDistance));
+	const topLeft = center
+		.clone()
+		.add(up.clone().multiplyScalar(halfHeight))
+		.sub(right.clone().multiplyScalar(halfWidth));
+	const topRight = center
+		.clone()
+		.add(up.clone().multiplyScalar(halfHeight))
+		.add(right.clone().multiplyScalar(halfWidth));
+	const bottomRight = center
+		.clone()
+		.sub(up.clone().multiplyScalar(halfHeight))
+		.add(right.clone().multiplyScalar(halfWidth));
+	const bottomLeft = center
+		.clone()
+		.sub(up.clone().multiplyScalar(halfHeight))
+		.sub(right.clone().multiplyScalar(halfWidth));
+
+	const fromHandle = handleByName(rig, "look_from");
+	const atHandle = handleByName(rig, "look_at");
+	if (fromHandle) {
+		fromHandle.position.copy(lookFrom);
+		fromHandle.scale.setScalar(selectedHandle === "look_from" ? 1.35 : 1);
+		(fromHandle.material as THREE.MeshBasicMaterial).color.setHex(
+			selectedHandle === "look_from"
+				? CAMERA_SELECTED_COLOR
+				: CAMERA_FROM_COLOR,
+		);
+	}
+	if (atHandle) {
+		atHandle.position.copy(lookAt);
+		atHandle.scale.setScalar(selectedHandle === "look_at" ? 1.35 : 1);
+		(atHandle.material as THREE.MeshBasicMaterial).color.setHex(
+			selectedHandle === "look_at" ? CAMERA_SELECTED_COLOR : CAMERA_AT_COLOR,
+		);
+	}
+
+	const aimLine = lineByName(rig, "CameraAimLine");
+	if (aimLine) setLinePoints(aimLine, [lookFrom, lookAt]);
+
+	const frustum = lineByName(rig, "CameraFrustum");
+	if (frustum) {
+		setLinePoints(frustum, [
+			lookFrom,
+			topLeft,
+			lookFrom,
+			topRight,
+			lookFrom,
+			bottomRight,
+			lookFrom,
+			bottomLeft,
+			topLeft,
+			topRight,
+			topRight,
+			bottomRight,
+			bottomRight,
+			bottomLeft,
+			bottomLeft,
+			topLeft,
+		]);
+	}
+
+	rig.visible = true;
 }
 
 // ── Patch types for incremental Three.js updates ────────────
@@ -141,12 +313,16 @@ interface Props {
 	isPlaying?: boolean;
 	selectedObjectKey: string | null;
 	onSelectObject: (key: string | null) => void;
+	selectedCameraHandle?: CameraHandle | null;
+	onSelectCameraHandle?: (handle: CameraHandle | null) => void;
+	cameraHandleEditingEnabled?: boolean;
 	/** Transform gizmo mode: "translate" | "rotate" | "scale" */
 	transformMode?: "translate" | "rotate" | "scale";
 	/** Coordinate space: "world" | "local" | "object" */
 	transformSpace?: "world" | "local";
 	/** Called when gizmo transform changes */
 	onTransformChange?: (objectKey: string, transform: StaticTransform) => void;
+	onCameraHandleChange?: (handle: CameraHandle, value: Vec3) => void;
 }
 
 /** Walk up the Three.js parent chain to find the first object with an objectKey. */
@@ -154,6 +330,16 @@ function findObjectKey(obj: THREE.Object3D): string | null {
 	let cur: THREE.Object3D | null = obj;
 	while (cur) {
 		if (cur.userData.objectKey) return cur.userData.objectKey as string;
+		cur = cur.parent;
+	}
+	return null;
+}
+
+function findCameraHandle(obj: THREE.Object3D): CameraHandle | null {
+	let cur: THREE.Object3D | null = obj;
+	while (cur) {
+		const handle = cur.userData.cameraHandle;
+		if (handle === "look_from" || handle === "look_at") return handle;
 		cur = cur.parent;
 	}
 	return null;
@@ -211,9 +397,13 @@ export function Viewport({
 	isPlaying = false,
 	selectedObjectKey,
 	onSelectObject,
+	selectedCameraHandle = null,
+	onSelectCameraHandle,
+	cameraHandleEditingEnabled = true,
 	transformMode = "translate",
 	transformSpace = "world",
 	onTransformChange,
+	onCameraHandleChange,
 	ref,
 }: Props & { ref?: Ref<ViewportHandle> }) {
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -227,6 +417,7 @@ export function Viewport({
 	const outlinePass = useRef<OutlinePass | null>(null);
 	const transformControls = useRef<TransformControls | null>(null);
 	const gizmoProxy = useRef<THREE.Group | null>(null);
+	const cameraRigGroup = useRef<THREE.Group | null>(null);
 	const gizmoAnchorTmp = useRef(new THREE.Vector3());
 	const isDraggingRef = useRef(false);
 	/** Drives gizmo re-attach after scene graph rebuild; reset when the Three tree is replaced. */
@@ -258,6 +449,24 @@ export function Viewport({
 	useEffect(() => {
 		currentTimeRef.current = currentTime;
 	}, [currentTime]);
+
+	useEffect(() => {
+		const rig = cameraRigGroup.current;
+		const currentScene = scene;
+		const cam = camera.current;
+		if (!rig) return;
+		if (!currentScene || !cam) {
+			rig.visible = false;
+			return;
+		}
+		updateCameraRig(
+			rig,
+			currentScene,
+			currentTime,
+			cam.aspect,
+			selectedCameraHandle,
+		);
+	}, [scene, currentTime, selectedCameraHandle]);
 
 	// ── Imperative handle: applyPatch ──
 	// Live, incremental updates for edit controls; full rebuilds happen elsewhere.
@@ -492,6 +701,11 @@ export function Viewport({
 		sc.add(proxy);
 		gizmoProxy.current = proxy;
 
+		const cameraRig = createCameraRig();
+		cameraRig.visible = false;
+		sc.add(cameraRig);
+		cameraRigGroup.current = cameraRig;
+
 		// Post-processing with OutlinePass
 		const comp = new EffectComposer(renderer);
 		comp.addPass(new RenderPass(sc, cam));
@@ -556,6 +770,11 @@ export function Viewport({
 			if (proxy?.userData.target) {
 				proxy.userData.target = null;
 			}
+			const cameraRig = cameraRigGroup.current;
+			if (cameraRig) {
+				sc.remove(cameraRig);
+				disposeCameraRig(cameraRig);
+			}
 			ctrl.dispose();
 			tctrl.removeEventListener("dragging-changed", handleDraggingChanged);
 			tctrl.dispose();
@@ -598,6 +817,7 @@ export function Viewport({
 			outlinePass.current = null;
 			transformControls.current = null;
 			gizmoProxy.current = null;
+			cameraRigGroup.current = null;
 		};
 	}, []);
 
@@ -881,6 +1101,55 @@ export function Viewport({
 		};
 	}, [selectedObjectKey, transformMode, onTransformChange]);
 
+	// --- Effect: attach translate gizmo to selected camera handle ---
+	useEffect(() => {
+		const tctrl = transformControls.current;
+		const rig = cameraRigGroup.current;
+		if (!tctrl || !rig) return;
+
+		if (
+			!selectedCameraHandle ||
+			selectedObjectKey ||
+			!cameraHandleEditingEnabled
+		) {
+			if (!selectedObjectKey) tctrl.detach();
+			return;
+		}
+
+		const handle = handleByName(rig, selectedCameraHandle);
+		if (!handle) return;
+
+		tctrl.setMode("translate");
+		tctrl.setSpace("world");
+		tctrl.attach(handle);
+
+		const onDraggingChanged = (event: THREE.Event & { value: unknown }) => {
+			handle.userData.isDragging = event.value;
+			isDraggingRef.current = Boolean(event.value);
+		};
+
+		const onChangeDuringDrag = () => {
+			if (isPlayingRef.current || !handle.userData.isDragging) return;
+			handle.updateMatrixWorld(true);
+			const p = handle.position;
+			onCameraHandleChange?.(selectedCameraHandle, [p.x, p.y, p.z]);
+		};
+
+		tctrl.addEventListener("change", onChangeDuringDrag);
+		tctrl.addEventListener("dragging-changed", onDraggingChanged);
+
+		return () => {
+			tctrl.removeEventListener("change", onChangeDuringDrag);
+			tctrl.removeEventListener("dragging-changed", onDraggingChanged);
+			handle.userData.isDragging = false;
+		};
+	}, [
+		selectedCameraHandle,
+		selectedObjectKey,
+		cameraHandleEditingEnabled,
+		onCameraHandleChange,
+	]);
+
 	// --- Effect: apply animated transforms; keep proxy snapped to target ---
 	useEffect(() => {
 		const grp = sceneGroup.current;
@@ -943,6 +1212,23 @@ export function Viewport({
 			const raycaster = new THREE.Raycaster();
 			raycaster.setFromCamera(mouse, cam);
 
+			const rig = cameraRigGroup.current;
+			if (rig) {
+				const cameraHits = raycaster.intersectObjects(rig.children, true);
+				const handleHit = cameraHits.find((hit) =>
+					findCameraHandle(hit.object),
+				);
+				if (handleHit) {
+					const handle = findCameraHandle(handleHit.object);
+					if (handle) {
+						onSelectCameraHandle?.(
+							handle === selectedCameraHandle ? null : handle,
+						);
+						return;
+					}
+				}
+			}
+
 			const targets: THREE.Object3D[] = [grp];
 			if (gizmoProxy.current) targets.push(gizmoProxy.current);
 			const hits = raycaster.intersectObjects(targets, true);
@@ -957,8 +1243,14 @@ export function Viewport({
 			}
 			// Click on empty space — deselect
 			onSelectObject(null);
+			onSelectCameraHandle?.(null);
 		},
-		[selectedObjectKey, onSelectObject],
+		[
+			selectedCameraHandle,
+			selectedObjectKey,
+			onSelectCameraHandle,
+			onSelectObject,
+		],
 	);
 
 	// Track mouse-down position to distinguish clicks from drags

--- a/apps/scene-previewer/src/components/Viewport.tsx
+++ b/apps/scene-previewer/src/components/Viewport.tsx
@@ -160,9 +160,9 @@ function updateCameraRig(
 	forward.normalize();
 	if (forward.lengthSq() < 1e-12) forward.set(0, 0, -1);
 
-	let right = new THREE.Vector3().crossVectors(forward, upHint).normalize();
+	let right = new THREE.Vector3().crossVectors(upHint, forward).normalize();
 	if (right.lengthSq() < 1e-12) right = new THREE.Vector3(1, 0, 0);
-	const up = new THREE.Vector3().crossVectors(right, forward).normalize();
+	const up = new THREE.Vector3().crossVectors(forward, right).normalize();
 
 	const halfHeight =
 		Math.tan(THREE.MathUtils.degToRad(cam.vfov) * 0.5) * planeDistance;

--- a/apps/scene-previewer/src/components/Viewport.tsx
+++ b/apps/scene-previewer/src/components/Viewport.tsx
@@ -186,6 +186,7 @@ function updateCameraRig(
 		.clone()
 		.sub(up.clone().multiplyScalar(halfHeight))
 		.sub(right.clone().multiplyScalar(halfWidth));
+	const cameraFrame = new THREE.Matrix4().makeBasis(right, up, forward);
 
 	const fromHandle = handleByName(rig, "look_from");
 	const atHandle = handleByName(rig, "look_at");
@@ -200,6 +201,7 @@ function updateCameraRig(
 	}
 	if (atHandle) {
 		atHandle.position.copy(lookAt);
+		atHandle.quaternion.setFromRotationMatrix(cameraFrame);
 		atHandle.scale.setScalar(selectedHandle === "look_at" ? 1.35 : 1);
 		(atHandle.material as THREE.MeshBasicMaterial).color.setHex(
 			selectedHandle === "look_at" ? CAMERA_SELECTED_COLOR : CAMERA_AT_COLOR,
@@ -1120,7 +1122,7 @@ export function Viewport({
 		if (!handle) return;
 
 		tctrl.setMode("translate");
-		tctrl.setSpace("world");
+		tctrl.setSpace(selectedCameraHandle === "look_at" ? "local" : "world");
 		tctrl.attach(handle);
 
 		const onDraggingChanged = (event: THREE.Event & { value: unknown }) => {

--- a/apps/scene-previewer/src/components/Viewport.tsx
+++ b/apps/scene-previewer/src/components/Viewport.tsx
@@ -426,6 +426,7 @@ export function Viewport({
 	const transformDraggingRef = useRef(false);
 	const controlsSettleUntilRef = useRef(0);
 	const gizmoAnchorTmp = useRef(new THREE.Vector3());
+	const cameraHandleWorldTmp = useRef(new THREE.Vector3());
 	const isDraggingRef = useRef(false);
 	/** Drives gizmo re-attach after scene graph rebuild; reset when the Three tree is replaced. */
 	const latestTransformRef = useRef<{
@@ -443,33 +444,14 @@ export function Viewport({
 		sceneVersion: number | null;
 	}>({ dirHandle: null, sceneVersion: null });
 
+	const prevDirHandle = useRef<FileSystemDirectoryHandle | null | undefined>(
+		undefined,
+	);
 	const latestSceneRef = useRef(scene);
-	useEffect(() => {
-		latestSceneRef.current = scene;
-	}, [scene]);
 
 	const currentTimeRef = useRef(currentTime);
-	useEffect(() => {
-		currentTimeRef.current = currentTime;
-	}, [currentTime]);
 
-	useEffect(() => {
-		const rig = cameraRigGroup.current;
-		const currentScene = scene;
-		const cam = camera.current;
-		if (!rig) return;
-		if (!currentScene || !cam) {
-			rig.visible = false;
-			return;
-		}
-		updateCameraRig(
-			rig,
-			currentScene,
-			currentTime,
-			cam.aspect,
-			selectedCameraHandle,
-		);
-	}, [scene, currentTime, selectedCameraHandle]);
+	const selectedCameraHandleRef = useRef(selectedCameraHandle);
 
 	const requestRender = useCallback(() => {
 		if (pendingRenderRef.current !== null || renderLoopRef.current !== null) {
@@ -480,6 +462,41 @@ export function Viewport({
 			renderFrameRef.current?.();
 		});
 	}, []);
+
+	const refreshCameraRig = useCallback(() => {
+		const rig = cameraRigGroup.current;
+		const currentScene = latestSceneRef.current;
+		const cam = camera.current;
+		if (!rig) return;
+		if (!currentScene || !cam) {
+			rig.visible = false;
+			requestRender();
+			return;
+		}
+		updateCameraRig(
+			rig,
+			currentScene,
+			currentTimeRef.current,
+			cam.aspect,
+			selectedCameraHandleRef.current,
+		);
+		requestRender();
+	}, [requestRender]);
+
+	useEffect(() => {
+		latestSceneRef.current = scene;
+		refreshCameraRig();
+	}, [scene, refreshCameraRig]);
+
+	useEffect(() => {
+		currentTimeRef.current = currentTime;
+		refreshCameraRig();
+	}, [currentTime, refreshCameraRig]);
+
+	useEffect(() => {
+		selectedCameraHandleRef.current = selectedCameraHandle;
+		refreshCameraRig();
+	}, [selectedCameraHandle, refreshCameraRig]);
 
 	const ensureRenderLoop = useCallback(() => {
 		if (renderLoopRef.current !== null) return;
@@ -827,6 +844,7 @@ export function Viewport({
 			cam.updateProjectionMatrix();
 			renderer.setSize(w, h);
 			comp.setSize(w, h);
+			refreshCameraRig();
 			requestRender();
 		});
 		ro.observe(container);
@@ -898,7 +916,7 @@ export function Viewport({
 			cameraRigGroup.current = null;
 			renderFrameRef.current = null;
 		};
-	}, [ensureRenderLoop, requestRender, stopScheduledRenders]);
+	}, [ensureRenderLoop, refreshCameraRig, requestRender, stopScheduledRenders]);
 
 	// --- Effect 2: rebuild scene objects on structural changes ---
 	useEffect(() => {
@@ -906,7 +924,16 @@ export function Viewport({
 		if (!currentScene || !dirHandle) return;
 
 		const sc = threeScene.current;
-		if (!sc) return;
+		const cam = camera.current;
+		const ctrl = controls.current;
+		if (!sc || !cam || !ctrl) return;
+
+		const isNewScene = dirHandle !== prevDirHandle.current;
+		prevDirHandle.current = dirHandle;
+		if (isNewScene) {
+			syncOrbitCameraToScene(cam, ctrl, currentScene, currentTimeRef.current);
+			refreshCameraRig();
+		}
 
 		if (
 			lastBuild.current.dirHandle === dirHandle &&
@@ -977,7 +1004,7 @@ export function Viewport({
 		return () => {
 			abortController.abort();
 		};
-	}, [dirHandle, scene, sceneVersion, requestRender]);
+	}, [dirHandle, scene, sceneVersion, refreshCameraRig, requestRender]);
 
 	// --- Effect 2b: live-reload skybox background when skybox data changes ---
 	// Avoids a full scene-graph rebuild for just a texture swap.
@@ -1012,6 +1039,7 @@ export function Viewport({
 						skyboxTextureRef.current = tex;
 					}
 					blobUrlsRef.current = [...blobUrlsRef.current, ...urls];
+					requestRender();
 				})
 				.catch((err) => {
 					revokeBlobUrls(urls);
@@ -1024,12 +1052,13 @@ export function Viewport({
 				skyboxTextureRef.current = null;
 			}
 			sc.background = new THREE.Color(0x0c0d0f);
+			requestRender();
 		}
 
 		return () => {
 			abortController.abort();
 		};
-	}, [dirHandle, scene]);
+	}, [dirHandle, scene, requestRender]);
 
 	// --- Effect 3: update outline when selection changes ---
 	useEffect(() => {
@@ -1281,8 +1310,10 @@ export function Viewport({
 		const onChangeDuringDrag = () => {
 			if (isPlayingRef.current || !handle.userData.isDragging) return;
 			handle.updateMatrixWorld(true);
-			const p = handle.position;
+			const p = cameraHandleWorldTmp.current;
+			handle.getWorldPosition(p);
 			onCameraHandleChange?.(selectedCameraHandle, [p.x, p.y, p.z]);
+			requestRender();
 		};
 
 		tctrl.addEventListener("change", onChangeDuringDrag);
@@ -1298,6 +1329,7 @@ export function Viewport({
 		selectedObjectKey,
 		cameraHandleEditingEnabled,
 		onCameraHandleChange,
+		requestRender,
 	]);
 
 	// --- Effect: apply animated transforms; keep proxy snapped to target ---

--- a/apps/scene-previewer/src/components/Viewport.tsx
+++ b/apps/scene-previewer/src/components/Viewport.tsx
@@ -23,7 +23,11 @@ import {
 	makeThreeMaterial,
 	revokeBlobUrls,
 } from "../services/scene-to-three";
-import { evaluateTransformAt } from "../services/transform";
+import {
+	cameraHasKeyframes,
+	evaluateCameraAt,
+	evaluateTransformAt,
+} from "../services/transform";
 import type {
 	Material,
 	ResolvedScene,
@@ -47,8 +51,9 @@ function syncOrbitCameraToScene(
 	cam: THREE.PerspectiveCamera,
 	ctrl: OrbitControls,
 	sceneData: ResolvedScene,
+	time = 0,
 ) {
-	const c = sceneData.camera;
+	const c = evaluateCameraAt(sceneData.camera, time);
 	cam.fov = c.vfov;
 	cam.position.set(...c.look_from);
 	ctrl.target.set(...c.look_at);
@@ -264,7 +269,7 @@ export function Viewport({
 				const cam = camera.current;
 				const ctrl = controls.current;
 				if (!currentScene || !cam || !ctrl) return;
-				syncOrbitCameraToScene(cam, ctrl, currentScene);
+				syncOrbitCameraToScene(cam, ctrl, currentScene, currentTimeRef.current);
 			},
 			applyPatch(scene: ResolvedScene, objectKey: string, patch: ThreePatch) {
 				const sc = threeScene.current;
@@ -611,7 +616,7 @@ export function Viewport({
 		const isNewScene = dirHandle !== prevDirHandle.current;
 		prevDirHandle.current = dirHandle;
 		if (isNewScene) {
-			syncOrbitCameraToScene(cam, ctrl, currentScene);
+			syncOrbitCameraToScene(cam, ctrl, currentScene, currentTimeRef.current);
 		}
 
 		if (
@@ -881,6 +886,12 @@ export function Viewport({
 		const grp = sceneGroup.current;
 		const currentScene = scene;
 		if (!grp || !currentScene) return;
+
+		const cam = camera.current;
+		const ctrl = controls.current;
+		if (cam && ctrl && cameraHasKeyframes(currentScene.camera)) {
+			syncOrbitCameraToScene(cam, ctrl, currentScene, currentTime);
+		}
 
 		const proxy = gizmoProxy.current;
 		const isDragging = isDraggingRef.current;

--- a/apps/scene-previewer/src/services/scene-parser.ts
+++ b/apps/scene-previewer/src/services/scene-parser.ts
@@ -5,6 +5,7 @@ import type {
 	AnimatedTransform,
 	Animation,
 	Camera,
+	CameraKeyframe,
 	DielectricMaterial,
 	ImageConfig,
 	InterpCurve,
@@ -81,7 +82,7 @@ function stemFromPath(path: string): string {
 
 function parseCamera(json: unknown): Camera {
 	if (!isObject(json)) throw new Error("camera: expected object");
-	return {
+	const camera: Camera = {
 		look_from: parseVec3(json.look_from, "camera.look_from"),
 		look_at: parseVec3(json.look_at, "camera.look_at"),
 		vup: parseVec3OrDefault(json.vup, "camera.vup", [0, 1, 0]),
@@ -97,6 +98,38 @@ function parseCamera(json: unknown): Camera {
 				? num(json.shutter_close, "camera.shutter_close", 0)
 				: undefined,
 	};
+	if (json.keyframes !== undefined) {
+		if (!Array.isArray(json.keyframes)) {
+			throw new Error("camera.keyframes: expected array");
+		}
+		if (json.keyframes.length < 1) {
+			throw new Error("camera.keyframes: expected at least one keyframe");
+		}
+		camera.keyframes = json.keyframes.map((kf, i) =>
+			parseCameraKeyframe(kf, `camera.keyframes[${i}]`),
+		);
+	}
+	return camera;
+}
+
+function parseCameraKeyframe(json: unknown, field: string): CameraKeyframe {
+	if (!isObject(json)) throw new Error(`${field}: expected object`);
+	const kf: CameraKeyframe = {
+		time: num(json.time, `${field}.time`),
+	};
+	if (json.look_from !== undefined)
+		kf.look_from = parseVec3(json.look_from, `${field}.look_from`);
+	if (json.look_at !== undefined)
+		kf.look_at = parseVec3(json.look_at, `${field}.look_at`);
+	if (json.vup !== undefined) kf.vup = parseVec3(json.vup, `${field}.vup`);
+	if (json.vfov !== undefined) kf.vfov = num(json.vfov, `${field}.vfov`);
+	if (json.aperture_radius !== undefined)
+		kf.aperture_radius = num(json.aperture_radius, `${field}.aperture_radius`);
+	if (json.focus_distance !== undefined)
+		kf.focus_distance = num(json.focus_distance, `${field}.focus_distance`);
+	if (json.curve !== undefined)
+		kf.curve = parseInterpCurve(json.curve, `${field}.curve`);
+	return kf;
 }
 
 // --- Materials ---

--- a/apps/scene-previewer/src/services/scene-serializer.ts
+++ b/apps/scene-previewer/src/services/scene-serializer.ts
@@ -42,7 +42,7 @@ function serializeCamera(c: Camera): Record<string, unknown> {
 	const sc = c.shutter_close ?? 0;
 	if (so !== 0) o.shutter_open = so;
 	if (sc !== 0) o.shutter_close = sc;
-	if (c.keyframes !== undefined) {
+	if (c.keyframes !== undefined && c.keyframes.length > 0) {
 		o.keyframes = c.keyframes.map(serializeCameraKeyframe);
 	}
 	return o;

--- a/apps/scene-previewer/src/services/scene-serializer.ts
+++ b/apps/scene-previewer/src/services/scene-serializer.ts
@@ -3,6 +3,7 @@
 import type {
 	Animation,
 	Camera,
+	CameraKeyframe,
 	InterpCurve,
 	Keyframe,
 	LayerData,
@@ -41,6 +42,21 @@ function serializeCamera(c: Camera): Record<string, unknown> {
 	const sc = c.shutter_close ?? 0;
 	if (so !== 0) o.shutter_open = so;
 	if (sc !== 0) o.shutter_close = sc;
+	if (c.keyframes !== undefined) {
+		o.keyframes = c.keyframes.map(serializeCameraKeyframe);
+	}
+	return o;
+}
+
+function serializeCameraKeyframe(k: CameraKeyframe): Record<string, unknown> {
+	const o: Record<string, unknown> = { time: k.time };
+	if (k.look_from !== undefined) o.look_from = k.look_from;
+	if (k.look_at !== undefined) o.look_at = k.look_at;
+	if (k.vup !== undefined) o.vup = k.vup;
+	if (k.vfov !== undefined) o.vfov = k.vfov;
+	if (k.aperture_radius !== undefined) o.aperture_radius = k.aperture_radius;
+	if (k.focus_distance !== undefined) o.focus_distance = k.focus_distance;
+	if (k.curve !== undefined) o.curve = serializeInterpCurve(k.curve);
 	return o;
 }
 

--- a/apps/scene-previewer/src/services/transform.ts
+++ b/apps/scene-previewer/src/services/transform.ts
@@ -1,6 +1,8 @@
 import * as THREE from "three";
 import type {
 	AnimatedTransform,
+	Camera,
+	CameraKeyframe,
 	InterpCurve,
 	Keyframe,
 	NodeTransform,
@@ -22,6 +24,17 @@ interface ResolvedKeyframe {
 	translate: Vec3;
 	rotate: Vec3;
 	scale: Vec3;
+	curve?: InterpCurve;
+}
+
+interface ResolvedCameraKeyframe {
+	time: number;
+	look_from: Vec3;
+	look_at: Vec3;
+	vup: Vec3;
+	vfov: number;
+	aperture_radius: number;
+	focus_distance: number;
 	curve?: InterpCurve;
 }
 
@@ -156,6 +169,58 @@ function buildResolvedKeyframes(keyframes: Keyframe[]): ResolvedKeyframe[] {
 	return out;
 }
 
+function buildResolvedCameraKeyframes(
+	camera: Camera,
+	keyframes: CameraKeyframe[],
+): ResolvedCameraKeyframe[] {
+	const sortedKfs = keyframes.toSorted((a, b) => a.time - b.time);
+	let lookFrom: Vec3 = [...camera.look_from] as Vec3;
+	let lookAt: Vec3 = [...camera.look_at] as Vec3;
+	let vup: Vec3 = [...camera.vup] as Vec3;
+	let vfov = camera.vfov;
+	let apertureRadius = camera.aperture_radius;
+	let focusDistance = camera.focus_distance;
+	const out: ResolvedCameraKeyframe[] = [];
+
+	for (const kf of sortedKfs) {
+		if (kf.look_from) lookFrom = [...kf.look_from] as Vec3;
+		if (kf.look_at) lookAt = [...kf.look_at] as Vec3;
+		if (kf.vup) vup = [...kf.vup] as Vec3;
+		if (kf.vfov !== undefined) vfov = kf.vfov;
+		if (kf.aperture_radius !== undefined) apertureRadius = kf.aperture_radius;
+		if (kf.focus_distance !== undefined) focusDistance = kf.focus_distance;
+		out.push({
+			time: kf.time,
+			look_from: [...lookFrom] as Vec3,
+			look_at: [...lookAt] as Vec3,
+			vup: [...vup] as Vec3,
+			vfov,
+			aperture_radius: apertureRadius,
+			focus_distance: focusDistance,
+			curve: kf.curve,
+		});
+	}
+
+	return out;
+}
+
+function cameraFromResolved(
+	camera: Camera,
+	resolved: ResolvedCameraKeyframe,
+	keyframes: CameraKeyframe[],
+): Camera {
+	return {
+		...camera,
+		look_from: [...resolved.look_from] as Vec3,
+		look_at: [...resolved.look_at] as Vec3,
+		vup: [...resolved.vup] as Vec3,
+		vfov: resolved.vfov,
+		aperture_radius: resolved.aperture_radius,
+		focus_distance: resolved.focus_distance,
+		keyframes,
+	};
+}
+
 function resolvedToStatic(k: ResolvedKeyframe): StaticTransform {
 	const out: StaticTransform = {
 		translate: [...k.translate] as Vec3,
@@ -224,6 +289,55 @@ export function evaluateTransformAt(
 	localU = Math.min(1, Math.max(0, localU));
 	const alpha = evaluateBezierEasing(k1.curve, localU);
 	return interpolateResolved(k0, k1, alpha);
+}
+
+export function cameraHasKeyframes(camera: Camera): boolean {
+	return (camera.keyframes?.length ?? 0) > 0;
+}
+
+export function evaluateCameraAt(camera: Camera, time: number): Camera {
+	const keyframes = camera.keyframes;
+	if (!keyframes || keyframes.length === 0) {
+		return { ...camera };
+	}
+
+	const sorted = buildResolvedCameraKeyframes(camera, keyframes);
+	if (sorted.length === 1) {
+		return cameraFromResolved(camera, sorted[0], keyframes);
+	}
+
+	const first = sorted[0];
+	const last = sorted[sorted.length - 1];
+	if (time <= first.time) {
+		return cameraFromResolved(camera, first, keyframes);
+	}
+	if (time >= last.time) {
+		return cameraFromResolved(camera, last, keyframes);
+	}
+
+	const hi = sorted.findIndex((k) => k.time > time);
+	const i = hi - 1;
+	const k0 = sorted[i];
+	const k1 = sorted[i + 1];
+	const dt = k1.time - k0.time;
+	if (dt <= 1e-20) {
+		return cameraFromResolved(camera, k1, keyframes);
+	}
+
+	const localU = Math.min(1, Math.max(0, (time - k0.time) / dt));
+	const alpha = evaluateBezierEasing(k1.curve, localU);
+	return {
+		...camera,
+		look_from: lerpVec3(k0.look_from, k1.look_from, alpha),
+		look_at: lerpVec3(k0.look_at, k1.look_at, alpha),
+		vup: lerpVec3(k0.vup, k1.vup, alpha),
+		vfov: k0.vfov + (k1.vfov - k0.vfov) * alpha,
+		aperture_radius:
+			k0.aperture_radius + (k1.aperture_radius - k0.aperture_radius) * alpha,
+		focus_distance:
+			k0.focus_distance + (k1.focus_distance - k0.focus_distance) * alpha,
+		keyframes,
+	};
 }
 
 const KEYFRAME_TIME_MATCH_EPS = 1e-4;

--- a/apps/scene-previewer/src/services/transform.ts
+++ b/apps/scene-previewer/src/services/transform.ts
@@ -204,6 +204,22 @@ function buildResolvedCameraKeyframes(
 	return out;
 }
 
+const resolvedCameraKeyframesCache = new WeakMap<
+	CameraKeyframe[],
+	ResolvedCameraKeyframe[]
+>();
+
+function getResolvedCameraKeyframes(
+	camera: Camera,
+	keyframes: CameraKeyframe[],
+): ResolvedCameraKeyframe[] {
+	const cached = resolvedCameraKeyframesCache.get(keyframes);
+	if (cached) return cached;
+	const resolved = buildResolvedCameraKeyframes(camera, keyframes);
+	resolvedCameraKeyframesCache.set(keyframes, resolved);
+	return resolved;
+}
+
 function cameraFromResolved(
 	camera: Camera,
 	resolved: ResolvedCameraKeyframe,
@@ -301,7 +317,7 @@ export function evaluateCameraAt(camera: Camera, time: number): Camera {
 		return { ...camera };
 	}
 
-	const sorted = buildResolvedCameraKeyframes(camera, keyframes);
+	const sorted = getResolvedCameraKeyframes(camera, keyframes);
 	if (sorted.length === 1) {
 		return cameraFromResolved(camera, sorted[0], keyframes);
 	}

--- a/apps/scene-previewer/src/types/scene.ts
+++ b/apps/scene-previewer/src/types/scene.ts
@@ -3,7 +3,25 @@
 
 export type Vec3 = [number, number, number];
 
+export type InterpCurve =
+	| "linear"
+	| "ease-in"
+	| "ease-out"
+	| "ease-in-out"
+	| { bezier: [number, number, number, number] };
+
 // --- Camera ---
+
+export interface CameraKeyframe {
+	time: number;
+	look_from?: Vec3;
+	look_at?: Vec3;
+	vup?: Vec3;
+	vfov?: number;
+	aperture_radius?: number;
+	focus_distance?: number;
+	curve?: InterpCurve;
+}
 
 export interface Camera {
 	look_from: Vec3;
@@ -15,6 +33,7 @@ export interface Camera {
 	/** Motion blur shutter (default 0). */
 	shutter_open?: number;
 	shutter_close?: number;
+	keyframes?: CameraKeyframe[];
 }
 
 // --- Materials ---
@@ -62,13 +81,6 @@ export interface NanoVDBMedium {
 export type Medium = NanoVDBMedium;
 
 // --- Transforms ---
-
-export type InterpCurve =
-	| "linear"
-	| "ease-in"
-	| "ease-out"
-	| "ease-in-out"
-	| { bezier: [number, number, number, number] };
 
 export interface Keyframe {
 	time: number;

--- a/apps/scene-previewer/src/types/scene.ts
+++ b/apps/scene-previewer/src/types/scene.ts
@@ -3,6 +3,8 @@
 
 export type Vec3 = [number, number, number];
 
+export type CameraHandle = "look_from" | "look_at";
+
 export type InterpCurve =
 	| "linear"
 	| "ease-in"

--- a/docs/reference/animation.md
+++ b/docs/reference/animation.md
@@ -27,6 +27,28 @@ Animation in Skewer is defined through **keyframed transforms** on scene graph n
 
 In this example, a group node rotates 360 degrees around the Y-axis from time 0 to time 1, carrying its child (the Earth model) in an orbital path.
 
+The scene camera can also be keyframed with `camera.keyframes`. Camera keyframes use the same time
+axis and patch-style carry-forward behavior, but animate camera fields instead of TRS:
+
+```json
+"camera": {
+  "look_from": [0, 2, 5],
+  "look_at": [0, 0, 0],
+  "vup": [0, 1, 0],
+  "vfov": 50,
+  "aperture_radius": 0.02,
+  "focus_distance": 5,
+  "keyframes": [
+    { "time": 0, "look_from": [0, 2, 5] },
+    { "time": 2, "look_from": [3, 2, 5], "focus_distance": 3, "aperture_radius": 0.08 }
+  ]
+}
+```
+
+Moving cameras are evaluated at each sampled ray time, so camera motion contributes true motion blur.
+Camera animation does not expand BVH/TLAS bounds because the scene geometry has not moved, but every
+render layer becomes frame-varying when the camera has more than one keyframe.
+
 ## Keyframe Structure
 
 Each keyframe in the `keyframes` array has:
@@ -193,9 +215,12 @@ Animated objects require expanded bounding volumes for the BVH acceleration stru
 Skewer uses a two-level BVH:
 
 - **Bottom-level BVH**: Static mesh geometry, built once per layer load
-- **Top-level BVH (TLAS)**: Instance transforms, rebuilt per ray time
+- **Top-level BVH (TLAS)**: Instance bounds over the shutter window; animated instance transforms
+  are evaluated at ray time during traversal
 
 For animated instances, the TLAS evaluates transforms at the ray's time. For static instances, the transform is precomputed at `t=0`.
+Animated cameras only change primary rays and deep-output camera depth projection; they do not require
+different BLAS/TLAS bounds.
 
 ### Static vs Animated Instances
 

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -14,7 +14,7 @@ The Scene Previewer uses the [File System Access API](https://developer.mozilla.
 
 ## Scene Camera
 
-The camera defined in `scene.json` is **static** — there is no camera animation path or moving camera support. The `look_from`, `look_at`, `vup`, and `vfov` values are fixed for the duration of a render.
+The camera defined in `scene.json` supports keyframed `look_from`, `look_at`, `vup`, `vfov`, `focus_distance`, and `aperture_radius` values. The previewer can load, save, and scrub animated cameras, but it does not yet provide camera keyframe authoring controls.
 
 The previewer viewport does provide interactive Three.js `OrbitControls` (orbit, pan, zoom) for inspection, but this does not affect the rendered output.
 

--- a/docs/reference/scene-format.md
+++ b/docs/reference/scene-format.md
@@ -67,6 +67,10 @@ The top-level file that orchestrates a render:
   "vfov": 60,
   "aperture_radius": 0.05,
   "focus_distance": 5.0,
+  "keyframes": [
+    { "time": 0.0, "look_from": [0, 2, 5] },
+    { "time": 2.0, "look_from": [3, 2, 5], "focus_distance": 3.0, "curve": "ease-in-out" }
+  ],
   "shutter_open": 0.0,
   "shutter_close": 0.1
 }
@@ -80,6 +84,7 @@ The top-level file that orchestrates a render:
 | `vfov`            | float | `90`        | Vertical field of view in degrees                                                   |
 | `aperture_radius` | float | `0`         | Lens aperture radius. `0` = no depth of field; >0 enables DOF with `focus_distance` |
 | `focus_distance`  | float | `1.0`       | Distance from camera that is in focus (meaningful when `aperture_radius > 0`)       |
+| `keyframes`       | array | —           | Optional camera animation keyframes                                                 |
 | `shutter_open`    | float | `0`         | Time when shutter opens (animation time units). Non-zero enables motion blur        |
 | `shutter_close`   | float | `0`         | Time when shutter closes. If equal to `shutter_open`, no motion blur                |
 
@@ -89,6 +94,11 @@ The top-level file that orchestrates a render:
 
 !!!important
     **Do not** set `shutter_open` and `shutter_close` for animated scenes. Instead, define the `shutter_angle` property in the [animation configuration](#animation).
+
+Camera keyframes are patch-based. Omitted fields carry forward from the previous camera keyframe,
+seeded by the static camera fields. The animatable fields are `look_from`, `look_at`, `vup`,
+`vfov`, `aperture_radius`, and `focus_distance`. When `camera.keyframes` has more than one entry,
+all layers are frame-varying because the view changes even if the layer geometry is static.
 
 ## Layer/Context Files
 

--- a/orchestration/internal/api/validate.go
+++ b/orchestration/internal/api/validate.go
@@ -47,6 +47,9 @@ func (v *SceneValidator) Validate(ctx context.Context, uploadPrefix, scenePath s
 	if err := json.Unmarshal(sceneBytes, &sceneMap); err != nil {
 		return "", fmt.Errorf("parse scene JSON: %w", err)
 	}
+	if err := validateCameraBlock(sceneMap["camera"]); err != nil {
+		return "", err
+	}
 	if err := validateAnimationBlock(sceneMap["animation"]); err != nil {
 		return "", err
 	}
@@ -100,6 +103,148 @@ func validateAnimationBlock(raw any) error {
 	}
 	if shutterAngle <= 0 || shutterAngle > 360 {
 		return fmt.Errorf("scene animation.shutter_angle must be in (0, 360]")
+	}
+	return nil
+}
+
+func validateCameraBlock(raw any) error {
+	camera, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("scene camera block is required")
+	}
+	for _, key := range []string{"look_from", "look_at"} {
+		if err := validateVec3(camera[key]); err != nil {
+			return fmt.Errorf("scene camera.%s %w", key, err)
+		}
+	}
+	if v, ok := camera["vup"]; ok {
+		if err := validateVec3(v); err != nil {
+			return fmt.Errorf("scene camera.vup %w", err)
+		}
+	}
+	if v, ok := camera["vfov"]; ok {
+		if err := validatePositiveNumber(v, "scene camera.vfov"); err != nil {
+			return err
+		}
+	}
+	if v, ok := camera["focus_distance"]; ok {
+		if err := validatePositiveNumber(v, "scene camera.focus_distance"); err != nil {
+			return err
+		}
+	}
+	if v, ok := camera["aperture_radius"]; ok {
+		if err := validateNonNegativeNumber(v, "scene camera.aperture_radius"); err != nil {
+			return err
+		}
+	}
+
+	rawKeyframes, present := camera["keyframes"]
+	if !present {
+		return nil
+	}
+	keyframes, ok := rawKeyframes.([]any)
+	if !ok || len(keyframes) == 0 {
+		return fmt.Errorf("scene camera.keyframes must be a non-empty array")
+	}
+	for i, rawKeyframe := range keyframes {
+		keyframe, ok := rawKeyframe.(map[string]any)
+		if !ok {
+			return fmt.Errorf("scene camera.keyframes[%d] must be an object", i)
+		}
+		if _, ok := keyframe["time"].(float64); !ok {
+			return fmt.Errorf("scene camera.keyframes[%d].time must be a number", i)
+		}
+		for _, key := range []string{"look_from", "look_at", "vup"} {
+			if v, ok := keyframe[key]; ok {
+				if err := validateVec3(v); err != nil {
+					return fmt.Errorf("scene camera.keyframes[%d].%s %w", i, key, err)
+				}
+			}
+		}
+		if v, ok := keyframe["vfov"]; ok {
+			if err := validatePositiveNumber(v, fmt.Sprintf("scene camera.keyframes[%d].vfov", i)); err != nil {
+				return err
+			}
+		}
+		if v, ok := keyframe["focus_distance"]; ok {
+			if err := validatePositiveNumber(v, fmt.Sprintf("scene camera.keyframes[%d].focus_distance", i)); err != nil {
+				return err
+			}
+		}
+		if v, ok := keyframe["aperture_radius"]; ok {
+			if err := validateNonNegativeNumber(v, fmt.Sprintf("scene camera.keyframes[%d].aperture_radius", i)); err != nil {
+				return err
+			}
+		}
+		if v, ok := keyframe["curve"]; ok {
+			if err := validateCurve(v); err != nil {
+				return fmt.Errorf("scene camera.keyframes[%d].curve %w", i, err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateVec3(raw any) error {
+	v, ok := raw.([]any)
+	if !ok || len(v) != 3 {
+		return fmt.Errorf("must be an array of 3 numbers")
+	}
+	for _, component := range v {
+		if _, ok := component.(float64); !ok {
+			return fmt.Errorf("must be an array of 3 numbers")
+		}
+	}
+	return nil
+}
+
+func validatePositiveNumber(raw any, field string) error {
+	v, ok := raw.(float64)
+	if !ok {
+		return fmt.Errorf("%s must be a number", field)
+	}
+	if v <= 0 {
+		return fmt.Errorf("%s must be positive", field)
+	}
+	return nil
+}
+
+func validateNonNegativeNumber(raw any, field string) error {
+	v, ok := raw.(float64)
+	if !ok {
+		return fmt.Errorf("%s must be a number", field)
+	}
+	if v < 0 {
+		return fmt.Errorf("%s must be non-negative", field)
+	}
+	return nil
+}
+
+func validateCurve(raw any) error {
+	if name, ok := raw.(string); ok {
+		switch name {
+		case "linear", "ease-in", "ease-out", "ease-in-out":
+			return nil
+		default:
+			return fmt.Errorf("unknown preset %q", name)
+		}
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("must be a preset string or {\"bezier\":[...]}")
+	}
+	rawBezier, ok := obj["bezier"]
+	if !ok {
+		return fmt.Errorf("must be a preset string or {\"bezier\":[...]}")
+	}
+	bezier, ok := rawBezier.([]any)
+	if !ok || len(bezier) != 4 {
+		return fmt.Errorf("bezier must be an array of 4 numbers")
+	}
+	for _, v := range bezier {
+		if _, ok := v.(float64); !ok {
+			return fmt.Errorf("bezier must be an array of 4 numbers")
+		}
 	}
 	return nil
 }

--- a/orchestration/internal/api/validate_test.go
+++ b/orchestration/internal/api/validate_test.go
@@ -99,6 +99,103 @@ func TestValidateAnimationBlockRequiresExplicitMetadata(t *testing.T) {
 	}
 }
 
+func TestValidateCameraBlock(t *testing.T) {
+	validBase := map[string]any{
+		"look_from":       []any{float64(0), float64(1), float64(4)},
+		"look_at":         []any{float64(0), float64(0), float64(0)},
+		"vup":             []any{float64(0), float64(1), float64(0)},
+		"vfov":            float64(50),
+		"focus_distance":  float64(4),
+		"aperture_radius": float64(0.1),
+	}
+
+	tests := []struct {
+		name    string
+		raw     any
+		wantErr string
+	}{
+		{
+			name:    "missing block",
+			raw:     nil,
+			wantErr: "scene camera block is required",
+		},
+		{
+			name: "missing look from",
+			raw: map[string]any{
+				"look_at": []any{float64(0), float64(0), float64(0)},
+			},
+			wantErr: "scene camera.look_from must be an array of 3 numbers",
+		},
+		{
+			name: "bad base vfov",
+			raw: map[string]any{
+				"look_from": []any{float64(0), float64(1), float64(4)},
+				"look_at":   []any{float64(0), float64(0), float64(0)},
+				"vfov":      float64(0),
+			},
+			wantErr: "scene camera.vfov must be positive",
+		},
+		{
+			name: "bad keyframe focus",
+			raw: map[string]any{
+				"look_from": []any{float64(0), float64(1), float64(4)},
+				"look_at":   []any{float64(0), float64(0), float64(0)},
+				"keyframes": []any{
+					map[string]any{"time": float64(0)},
+					map[string]any{"time": float64(1), "focus_distance": float64(0)},
+				},
+			},
+			wantErr: "scene camera.keyframes[1].focus_distance must be positive",
+		},
+		{
+			name: "bad keyframe curve",
+			raw: map[string]any{
+				"look_from": []any{float64(0), float64(1), float64(4)},
+				"look_at":   []any{float64(0), float64(0), float64(0)},
+				"keyframes": []any{
+					map[string]any{"time": float64(0), "curve": "unknown"},
+				},
+			},
+			wantErr: "scene camera.keyframes[0].curve unknown preset",
+		},
+		{
+			name: "valid",
+			raw:  validBase,
+		},
+		{
+			name: "valid keyframes",
+			raw: map[string]any{
+				"look_from": []any{float64(0), float64(1), float64(4)},
+				"look_at":   []any{float64(0), float64(0), float64(0)},
+				"keyframes": []any{
+					map[string]any{"time": float64(0)},
+					map[string]any{
+						"time":            float64(1),
+						"look_from":       []any{float64(1), float64(1), float64(4)},
+						"aperture_radius": float64(0.2),
+						"curve":           map[string]any{"bezier": []any{float64(0.2), float64(0.3), float64(0.8), float64(0.9)}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCameraBlock(tc.raw)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateCameraBlock() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validateCameraBlock() error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestSceneReferenceValidation(t *testing.T) {
 	scene := map[string]any{
 		"layers": []any{"layer_background.json", "layer_subject.json"},

--- a/orchestration/internal/coordinator/cloud.go
+++ b/orchestration/internal/coordinator/cloud.go
@@ -113,8 +113,11 @@ type layerDescriptor struct {
 // minimalSceneJSON is the minimal subset of scene.json parsed by the coordinator.
 // It mirrors the keys in the C++ SceneConfig / LoadSceneFile.
 type minimalSceneJSON struct {
-	Layers    []string `json:"layers"`
-	Context   []string `json:"context"`
+	Layers  []string `json:"layers"`
+	Context []string `json:"context"`
+	Camera  *struct {
+		Keyframes []map[string]any `json:"keyframes"`
+	} `json:"camera"`
 	Animation *struct {
 		Start        float64 `json:"start"`
 		End          float64 `json:"end"`
@@ -153,6 +156,7 @@ func (m *GCPManager) ExecutePipeline(ctx context.Context, req *pb.SubmitPipeline
 			numFrames = int(math.Round(dur * a.FPS))
 		}
 	}
+	cameraAnimated := sceneJSON.Camera != nil && len(sceneJSON.Camera.Keyframes) > 1
 
 	// Resolve layer URIs relative to the scene URI.
 	sceneBase := gcsURIDir(req.SceneUri)
@@ -173,7 +177,7 @@ func (m *GCPManager) ExecutePipeline(ctx context.Context, req *pb.SubmitPipeline
 		}
 
 		mode := "static"
-		if animated {
+		if animated || cameraAnimated {
 			mode = "animated"
 		}
 

--- a/orchestration/internal/coordinator/cloud_test.go
+++ b/orchestration/internal/coordinator/cloud_test.go
@@ -35,19 +35,22 @@ func TestNumFramesFromAnimation(t *testing.T) {
 // TestLayerClassification verifies that the animated flag is correctly mapped to mode.
 func TestLayerClassification(t *testing.T) {
 	cases := []struct {
-		animated bool
-		wantMode string
+		layerAnimated  bool
+		cameraAnimated bool
+		wantMode       string
 	}{
-		{true, "animated"},
-		{false, "static"},
+		{true, false, "animated"},
+		{false, false, "static"},
+		{false, true, "animated"},
 	}
 	for _, tc := range cases {
 		mode := "static"
-		if tc.animated {
+		if tc.layerAnimated || tc.cameraAnimated {
 			mode = "animated"
 		}
 		if mode != tc.wantMode {
-			t.Errorf("animated=%v → mode=%q, want %q", tc.animated, mode, tc.wantMode)
+			t.Errorf("layerAnimated=%v cameraAnimated=%v mode=%q, want %q",
+				tc.layerAnimated, tc.cameraAnimated, mode, tc.wantMode)
 		}
 	}
 }
@@ -57,6 +60,7 @@ func TestSceneJSONParsing(t *testing.T) {
 	raw := `{
 		"layers": ["layers/smoke.json", "layers/char.json"],
 		"context": ["ctx/lights.json"],
+		"camera": {"keyframes": [{"time": 0}, {"time": 1}]},
 		"animation": {"start": 0, "end": 5, "fps": 24, "shutter_angle": 180}
 	}`
 	var sceneJSON minimalSceneJSON
@@ -74,6 +78,9 @@ func TestSceneJSONParsing(t *testing.T) {
 	}
 	if sceneJSON.Animation.FPS != 24 {
 		t.Errorf("fps: want 24, got %v", sceneJSON.Animation.FPS)
+	}
+	if sceneJSON.Camera == nil || len(sceneJSON.Camera.Keyframes) != 2 {
+		t.Fatalf("camera keyframes not parsed: %#v", sceneJSON.Camera)
 	}
 	frames := numFramesFromAnimation(sceneJSON.Animation.Start, sceneJSON.Animation.End, sceneJSON.Animation.FPS)
 	if frames != 120 {

--- a/skewer/apps/worker/main.cc
+++ b/skewer/apps/worker/main.cc
@@ -121,9 +121,7 @@ static int RunBatchMode() {
             scene->SetShutter(t0, t1);
             scene->Build();  // rebuilds BVH with correct motion bounds for this shutter
 
-            auto cam = std::make_unique<skwr::Camera>(config.look_from, config.look_at, config.vup,
-                                                      config.vfov, aspect, config.aperture_radius,
-                                                      config.focus_distance, t0, t1);
+            auto cam = std::make_unique<skwr::Camera>(config.camera_timeline, aspect, t0, t1);
             opts.integrator_config.cam_w = -cam->GetW();
 
             auto film =

--- a/skewer/src/integrators/path_trace.cc
+++ b/skewer/src/integrators/path_trace.cc
@@ -89,7 +89,8 @@ void PathTrace::Render(const Scene& scene, const Camera& cam, Film* film,
                         float v = 1.0f - (float(y) + rng.UniformFloat()) / height;
 
                         SampledWavelengths wl = WavelengthSampler::Sample(rng.UniformFloat());
-                        Ray r = cam.GetRay(u, v, rng);
+                        Vec3 primary_cam_w;
+                        Ray r = cam.GetRay(u, v, rng, &primary_cam_w);
 
                         if (global_med != 0) {
                             // Global medium usually has priority 0 so bounded media can override it
@@ -98,7 +99,7 @@ void PathTrace::Render(const Scene& scene, const Camera& cam, Film* film,
 
                         SampleWriter writer(film, x, y, 1.0f, is_adaptive, config.enable_deep);
 
-                        Li(r, scene, rng, config, wl, writer);
+                        Li(r, scene, rng, config, primary_cam_w, wl, writer);
 
                         samples_taken++;
 

--- a/skewer/src/io/scene_loader.cc
+++ b/skewer/src/io/scene_loader.cc
@@ -1,5 +1,6 @@
 #include "io/scene_loader.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -8,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "core/cpu_config.h"
@@ -62,6 +64,92 @@ static Vec3 GetVec3Or(const json& j, const std::string& key, const Vec3& default
         return ParseVec3(j[key]);
     }
     return default_value;
+}
+
+static void ValidateCameraState(const CameraState& state, const std::string& filepath) {
+    if (!(state.vfov > 0.0f)) {
+        throw std::runtime_error("camera.vfov must be positive in: " + filepath);
+    }
+    if (!(state.focus_distance > 0.0f)) {
+        throw std::runtime_error("camera.focus_distance must be positive in: " + filepath);
+    }
+    if (state.aperture_radius < 0.0f) {
+        throw std::runtime_error("camera.aperture_radius must be non-negative in: " + filepath);
+    }
+}
+
+static void PatchCameraFields(const json& j, CameraState& state) {
+    if (j.contains("look_from")) {
+        state.look_from = ParseVec3(j["look_from"]);
+    }
+    if (j.contains("look_at")) {
+        state.look_at = ParseVec3(j["look_at"]);
+    }
+    if (j.contains("vup")) {
+        state.vup = ParseVec3(j["vup"]);
+    }
+    if (j.contains("vfov")) {
+        state.vfov = j["vfov"].get<float>();
+    }
+    if (j.contains("aperture_radius")) {
+        state.aperture_radius = j["aperture_radius"].get<float>();
+    }
+    if (j.contains("focus_distance")) {
+        state.focus_distance = j["focus_distance"].get<float>();
+    }
+}
+
+static CameraTimeline ParseCameraTimelineJson(const json& cam, const std::string& filepath) {
+    CameraTimeline timeline;
+    timeline.base.look_from = ParseVec3(cam.at("look_from"));
+    timeline.base.look_at = ParseVec3(cam.at("look_at"));
+    timeline.base.vup = GetVec3Or(cam, "vup", Vec3(0.0f, 1.0f, 0.0f));
+    timeline.base.vfov = GetOr(cam, "vfov", 90.0f);
+    timeline.base.aperture_radius = GetOr(cam, "aperture_radius", 0.0f);
+    timeline.base.focus_distance = GetOr(cam, "focus_distance", 1.0f);
+    ValidateCameraState(timeline.base, filepath);
+
+    if (!cam.contains("keyframes")) {
+        return timeline;
+    }
+
+    const auto& kfs = cam.at("keyframes");
+    if (!kfs.is_array() || kfs.empty()) {
+        throw std::runtime_error("camera.keyframes must be a non-empty array in: " + filepath);
+    }
+
+    std::vector<json> sorted_kfs;
+    sorted_kfs.reserve(kfs.size());
+    for (const auto& kf : kfs) {
+        if (!kf.is_object()) {
+            throw std::runtime_error("camera.keyframes entries must be objects in: " + filepath);
+        }
+        if (!kf.contains("time") || !kf["time"].is_number()) {
+            throw std::runtime_error("camera.keyframes entries must contain numeric time in: " +
+                                     filepath);
+        }
+        sorted_kfs.push_back(kf);
+    }
+    std::sort(sorted_kfs.begin(), sorted_kfs.end(), [](const json& a, const json& b) {
+        return a.at("time").get<float>() < b.at("time").get<float>();
+    });
+
+    CameraState cur = timeline.base;
+    for (const auto& kf : sorted_kfs) {
+        CameraKeyframe key;
+        key.time = kf.at("time").get<float>();
+        PatchCameraFields(kf, cur);
+        ValidateCameraState(cur, filepath);
+        key.state = cur;
+        if (kf.contains("curve")) {
+            key.curve = ParseCurveJson(kf["curve"]);
+        } else {
+            key.curve = ParseCurveJson(json("linear"));
+        }
+        timeline.keyframes.push_back(std::move(key));
+    }
+    timeline.SortKeyframes();
+    return timeline;
 }
 
 static RGB GetRGBOr(const json& j, const std::string& key, const RGB& default_value) {
@@ -516,12 +604,13 @@ SceneConfig LoadSceneFile(const std::string& filepath) {
 
     // Parse camera
     const auto& cam = j["camera"];
-    config.look_from = ParseVec3(cam.at("look_from"));
-    config.look_at = ParseVec3(cam.at("look_at"));
-    config.vup = GetVec3Or(cam, "vup", Vec3(0.0f, 1.0f, 0.0f));
-    config.vfov = GetOr(cam, "vfov", 90.0f);
-    config.aperture_radius = GetOr(cam, "aperture_radius", 0.0f);
-    config.focus_distance = GetOr(cam, "focus_distance", 1.0f);
+    config.camera_timeline = ParseCameraTimelineJson(cam, filepath);
+    config.look_from = config.camera_timeline.base.look_from;
+    config.look_at = config.camera_timeline.base.look_at;
+    config.vup = config.camera_timeline.base.vup;
+    config.vfov = config.camera_timeline.base.vfov;
+    config.aperture_radius = config.camera_timeline.base.aperture_radius;
+    config.focus_distance = config.camera_timeline.base.focus_distance;
     config.shutter_open = GetOr(cam, "shutter_open", 0.0f);
     config.shutter_close = GetOr(cam, "shutter_close", 0.0f);
 

--- a/skewer/src/io/scene_loader.cc
+++ b/skewer/src/io/scene_loader.cc
@@ -143,12 +143,9 @@ static CameraTimeline ParseCameraTimelineJson(const json& cam, const std::string
         key.state = cur;
         if (kf.contains("curve")) {
             key.curve = ParseCurveJson(kf["curve"]);
-        } else {
-            key.curve = ParseCurveJson(json("linear"));
         }
         timeline.keyframes.push_back(std::move(key));
     }
-    timeline.SortKeyframes();
     return timeline;
 }
 
@@ -715,6 +712,11 @@ SceneConfig LoadSceneFile(const std::string& filepath) {
         }
 
         config.animation = anim;
+    }
+    if (config.camera_timeline.IsAnimated() && !config.animation) {
+        throw std::runtime_error(
+            "camera.keyframes with more than one entry requires an animation block in: " +
+            filepath);
     }
 
     // Output directory (local path or cloud URI — used as-is, not resolved)

--- a/skewer/src/io/scene_loader.h
+++ b/skewer/src/io/scene_loader.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "core/math/vec3.h"
+#include "scene/camera.h"
 #include "session/render_options.h"
 
 namespace skwr {
@@ -63,6 +64,7 @@ struct SceneConfig {
     float focus_distance = 1.0f;
     float shutter_open = 0.0f;
     float shutter_close = 0.0f;
+    CameraTimeline camera_timeline;
 
     // Context layer paths (resolved to absolute paths)
     std::vector<std::string> context_paths;

--- a/skewer/src/kernels/path_kernel.cc
+++ b/skewer/src/kernels/path_kernel.cc
@@ -48,7 +48,7 @@ namespace skwr {
  * |- Deferred Deep Output pass
  */
 void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& config,
-        const SampledWavelengths& wl, SampleWriter& writer) {
+        const Vec3& primary_cam_w, const SampledWavelengths& wl, SampleWriter& writer) {
     Spectrum L(0.0f);     // Accumulated Radiance (color)
     Spectrum beta(1.0f);  // Throughput (attenuation)
     Ray r = ray;
@@ -291,7 +291,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
         dpr.UpdateBSDFWeight(beta, current_beta);
     }
 
-    dpr.ResolveToDeep(writer, ray, config.cam_w, wl);
+    dpr.ResolveToDeep(writer, ray, primary_cam_w, wl);
     const float out_alpha = (config.transparent_background && !saw_visible) ? 0.0f : 1.0f;
     writer.WriteBeauty(SpectrumToRGB(L, wl), out_alpha);
     writer.FlushDeepSegments();

--- a/skewer/src/kernels/path_kernel.h
+++ b/skewer/src/kernels/path_kernel.h
@@ -1,6 +1,7 @@
 #ifndef SKWR_KERNELS_PATH_KERNEL_H_
 #define SKWR_KERNELS_PATH_KERNEL_H_
 
+#include "core/math/vec3.h"
 #include "core/spectral/spectrum.h"
 #include "film/sample_writer.h"
 
@@ -12,7 +13,7 @@ class RNG;
 struct IntegratorConfig;
 
 void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& config,
-        const SampledWavelengths& wl, SampleWriter& writer);
+        const Vec3& primary_cam_w, const SampledWavelengths& wl, SampleWriter& writer);
 
 }  // namespace skwr
 

--- a/skewer/src/scene/camera.h
+++ b/skewer/src/scene/camera.h
@@ -1,15 +1,102 @@
 #ifndef SKWR_SCENE_CAMERA_H_
 #define SKWR_SCENE_CAMERA_H_
 
+#include <algorithm>
 #include <cmath>
+#include <iterator>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include "core/math/constants.h"
 #include "core/math/vec3.h"
 #include "core/ray.h"
 #include "core/sampling/rng.h"
 #include "core/sampling/sampling.h"
+#include "scene/interp_curve.h"
 
 namespace skwr {
+
+struct CameraState {
+    Vec3 look_from;
+    Vec3 look_at;
+    Vec3 vup = Vec3(0.0f, 1.0f, 0.0f);
+    float vfov = 90.0f;
+    float aperture_radius = 0.0f;
+    float focus_distance = 1.0f;
+};
+
+struct CameraKeyframe {
+    float time = 0.0f;
+    CameraState state;
+    std::shared_ptr<const InterpolationCurve> curve;
+};
+
+struct CameraTimeline {
+    CameraState base;
+    std::vector<CameraKeyframe> keyframes;
+
+    bool IsAnimated() const { return keyframes.size() > 1; }
+    CameraState Evaluate(float t) const {
+        if (keyframes.empty()) {
+            return base;
+        }
+        if (keyframes.size() == 1) {
+            return keyframes[0].state;
+        }
+
+        const CameraKeyframe& first = keyframes.front();
+        const CameraKeyframe& last = keyframes.back();
+        if (t <= first.time) {
+            return first.state;
+        }
+        if (t >= last.time) {
+            return last.state;
+        }
+
+        auto it =
+            std::upper_bound(keyframes.begin(), keyframes.end(), t,
+                             [](float time, const CameraKeyframe& k) { return time < k.time; });
+        size_t i = static_cast<size_t>(std::distance(keyframes.begin(), it)) - 1;
+        const CameraKeyframe& k0 = keyframes[i];
+        const CameraKeyframe& k1 = keyframes[i + 1];
+        float dt = k1.time - k0.time;
+        if (dt <= 1e-20f) {
+            return k1.state;
+        }
+
+        float local_u = std::clamp((t - k0.time) / dt, 0.0f, 1.0f);
+        float alpha =
+            k1.curve ? k1.curve->Evaluate(local_u) : BezierCurve::Linear().Evaluate(local_u);
+
+        CameraState out;
+        out.look_from = k0.state.look_from + (k1.state.look_from - k0.state.look_from) * alpha;
+        out.look_at = k0.state.look_at + (k1.state.look_at - k0.state.look_at) * alpha;
+        out.vup = k0.state.vup + (k1.state.vup - k0.state.vup) * alpha;
+        out.vfov = k0.state.vfov + (k1.state.vfov - k0.state.vfov) * alpha;
+        out.aperture_radius = k0.state.aperture_radius +
+                              (k1.state.aperture_radius - k0.state.aperture_radius) * alpha;
+        out.focus_distance =
+            k0.state.focus_distance + (k1.state.focus_distance - k0.state.focus_distance) * alpha;
+        return out;
+    }
+
+    void SortKeyframes() {
+        std::sort(keyframes.begin(), keyframes.end(),
+                  [](const CameraKeyframe& a, const CameraKeyframe& b) { return a.time < b.time; });
+    }
+};
+
+struct CameraFrame {
+    Vec3 origin;
+    Vec3 lower_left_corner;
+    Vec3 horizontal;
+    Vec3 vertical;
+    Vec3 u;
+    Vec3 v;
+    Vec3 w;
+    float lens_radius = 0.0f;
+};
 
 // LookAt camera with thin-lens depth of field.
 // Set aperture_radius=0 (default) for a pinhole camera.
@@ -18,54 +105,80 @@ class Camera {
     Camera(const Vec3& look_from, const Vec3& look_at, const Vec3& vup, float vfov,
            float aspect_ratio, float aperture_radius = 0.0f, float focus_distance = 1.0f,
            float shutter_open = 0.0f, float shutter_close = 0.0f)
-        : shutter_open_(shutter_open), shutter_close_(shutter_close) {
-        auto theta = vfov * MathConstants::kPi / 180.0f;
+        : Camera(MakeStaticTimeline(look_from, look_at, vup, vfov, aperture_radius, focus_distance),
+                 aspect_ratio, shutter_open, shutter_close) {}
+
+    Camera(CameraTimeline timeline, float aspect_ratio, float shutter_open = 0.0f,
+           float shutter_close = 0.0f)
+        : timeline_(std::move(timeline)),
+          aspect_ratio_(aspect_ratio),
+          shutter_open_(shutter_open),
+          shutter_close_(shutter_close),
+          animated_(timeline_.IsAnimated()),
+          static_frame_(BuildFrame(timeline_.Evaluate(shutter_open_), aspect_ratio_)) {}
+
+    // Ray generation: takes normalized coords [0,1] and returns a world-space ray.
+    // When lens_radius_ > 0, applies thin-lens DoF by sampling the aperture disk.
+    Ray GetRay(float s, float t, RNG& rng, Vec3* cam_forward = nullptr) const {
+        float ray_time = shutter_open_ + rng.UniformFloat() * (shutter_close_ - shutter_open_);
+        const CameraFrame frame =
+            animated_ ? BuildFrame(timeline_.Evaluate(ray_time), aspect_ratio_) : static_frame_;
+        if (cam_forward != nullptr) {
+            *cam_forward = -frame.w;
+        }
+
+        Vec3 offset(0.0f, 0.0f, 0.0f);
+        if (frame.lens_radius > 0.0f) {
+            Vec3 rd = RandomInUnitDisk(rng) * frame.lens_radius;
+            offset = frame.u * rd.x() + frame.v * rd.y();
+        }
+        Vec3 focal_point = frame.lower_left_corner + frame.horizontal * s + frame.vertical * t;
+        Vec3 dir = Normalize(focal_point - frame.origin - offset);
+        return Ray(frame.origin + offset, dir, ray_time);
+    }
+
+    Vec3 GetW() const { return static_frame_.w; }
+    const CameraTimeline& Timeline() const { return timeline_; }
+
+  private:
+    static CameraTimeline MakeStaticTimeline(const Vec3& look_from, const Vec3& look_at,
+                                             const Vec3& vup, float vfov, float aperture_radius,
+                                             float focus_distance) {
+        CameraTimeline timeline;
+        timeline.base.look_from = look_from;
+        timeline.base.look_at = look_at;
+        timeline.base.vup = vup;
+        timeline.base.vfov = vfov;
+        timeline.base.aperture_radius = aperture_radius;
+        timeline.base.focus_distance = focus_distance;
+        return timeline;
+    }
+
+    static CameraFrame BuildFrame(const CameraState& state, float aspect_ratio) {
+        auto theta = state.vfov * MathConstants::kPi / 180.0f;
         auto h = std::tan(theta / 2.0f);
         auto viewport_height = 2.0f * h;
         auto viewport_width = aspect_ratio * viewport_height;
 
-        // Calculate basis vecs
-        w_ = Normalize(look_from - look_at);  // inverse forward (points backwards)
-        u_ = Normalize(Cross(vup, w_));       // right
-        v_ = Cross(w_, u_);                   // up
-
-        origin_ = look_from;
-        lens_radius_ = aperture_radius;
-
-        // Scale viewport by focus_distance so all rays through a pixel converge at the focus plane
-        horizontal_ = u_ * (viewport_width * focus_distance);
-        vertical_ = v_ * (viewport_height * focus_distance);
-
-        // Lower left corner of image
-        lower_left_corner_ = origin_ - horizontal_ / 2.0f - vertical_ / 2.0f - w_ * focus_distance;
+        CameraFrame frame;
+        frame.w = Normalize(state.look_from - state.look_at);  // inverse forward
+        frame.u = Normalize(Cross(state.vup, frame.w));
+        frame.v = Cross(frame.w, frame.u);
+        frame.origin = state.look_from;
+        frame.lens_radius = state.aperture_radius;
+        frame.horizontal = frame.u * (viewport_width * state.focus_distance);
+        frame.vertical = frame.v * (viewport_height * state.focus_distance);
+        frame.lower_left_corner = frame.origin - frame.horizontal / 2.0f - frame.vertical / 2.0f -
+                                  frame.w * state.focus_distance;
+        return frame;
     }
 
-    // Ray generation: takes normalized coords [0,1] and returns a world-space ray.
-    // When lens_radius_ > 0, applies thin-lens DoF by sampling the aperture disk.
-    Ray GetRay(float s, float t, RNG& rng) const {
-        Vec3 offset(0.0f, 0.0f, 0.0f);
-        if (lens_radius_ > 0.0f) {
-            Vec3 rd = RandomInUnitDisk(rng) * lens_radius_;
-            offset = u_ * rd.x() + v_ * rd.y();
-        }
-        Vec3 focal_point = lower_left_corner_ + horizontal_ * s + vertical_ * t;
-        Vec3 dir = Normalize(focal_point - origin_ - offset);
-        float ray_time = shutter_open_ + rng.UniformFloat() * (shutter_close_ - shutter_open_);
-        return Ray(origin_ + offset, dir, ray_time);
-    }
-
-    Vec3 GetW() const { return w_; }
-
-  private:
-    Vec3 origin_;
-    Vec3 lower_left_corner_;  // We are using a standard right-handed system +X: Right, +Y: Up, -Z:
-                              // Forward (Into the screen)
-    Vec3 horizontal_;
-    Vec3 vertical_;
-    Vec3 u_, v_, w_;
-    float lens_radius_ = 0.0f;
+    CameraTimeline timeline_;
+    float aspect_ratio_ = 1.0f;
     float shutter_open_ = 0.0f;
     float shutter_close_ = 0.0f;
+    bool animated_ = false;
+    CameraFrame static_frame_;
 };
 
 }  // namespace skwr

--- a/skewer/src/scene/camera.h
+++ b/skewer/src/scene/camera.h
@@ -128,8 +128,7 @@ class Camera {
     // When lens_radius_ > 0, applies thin-lens DoF by sampling the aperture disk.
     Ray GetRay(float s, float t, RNG& rng, Vec3* cam_forward = nullptr) const {
         float ray_time = shutter_open_ + rng.UniformFloat() * (shutter_close_ - shutter_open_);
-        const CameraFrame frame =
-            animated_ ? InterpolateFrame(ray_time) : static_frame_;
+        const CameraFrame frame = animated_ ? InterpolateFrame(ray_time) : static_frame_;
         if (cam_forward != nullptr) {
             *cam_forward = -frame.w;
         }
@@ -189,10 +188,9 @@ class Camera {
         if (t <= first_time) return keyframe_frames_.front();
         if (t >= last_time) return keyframe_frames_.back();
 
-        auto it = std::upper_bound(kfs.begin(), kfs.end(), t,
-                                   [](float time, const CameraKeyframe& k) {
-                                       return time < k.time;
-                                   });
+        auto it =
+            std::upper_bound(kfs.begin(), kfs.end(), t,
+                             [](float time, const CameraKeyframe& k) { return time < k.time; });
         size_t i = static_cast<size_t>(std::distance(kfs.begin(), it)) - 1;
 
         const CameraKeyframe& k0 = kfs[i];
@@ -201,8 +199,8 @@ class Camera {
         if (dt <= 1e-20f) return keyframe_frames_[i + 1];
 
         float local_u = std::clamp((t - k0.time) / dt, 0.0f, 1.0f);
-        float alpha = k1.curve ? k1.curve->Evaluate(local_u)
-                               : BezierCurve::Linear().Evaluate(local_u);
+        float alpha =
+            k1.curve ? k1.curve->Evaluate(local_u) : BezierCurve::Linear().Evaluate(local_u);
 
         const CameraFrame& f0 = keyframe_frames_[i];
         const CameraFrame& f1 = keyframe_frames_[i + 1];
@@ -219,9 +217,7 @@ class Camera {
         return out;
     }
 
-    static Vec3 LerpVec3(const Vec3& a, const Vec3& b, float t) {
-        return a + (b - a) * t;
-    }
+    static Vec3 LerpVec3(const Vec3& a, const Vec3& b, float t) { return a + (b - a) * t; }
 
     CameraTimeline timeline_;
     float aspect_ratio_ = 1.0f;

--- a/skewer/src/scene/camera.h
+++ b/skewer/src/scene/camera.h
@@ -115,14 +115,21 @@ class Camera {
           shutter_open_(shutter_open),
           shutter_close_(shutter_close),
           animated_(timeline_.IsAnimated()),
-          static_frame_(BuildFrame(timeline_.Evaluate(shutter_open_), aspect_ratio_)) {}
+          static_frame_(BuildFrame(timeline_.Evaluate(shutter_open_), aspect_ratio_)) {
+        if (animated_) {
+            keyframe_frames_.reserve(timeline_.keyframes.size());
+            for (const auto& kf : timeline_.keyframes) {
+                keyframe_frames_.push_back(BuildFrame(kf.state, aspect_ratio_));
+            }
+        }
+    }
 
     // Ray generation: takes normalized coords [0,1] and returns a world-space ray.
     // When lens_radius_ > 0, applies thin-lens DoF by sampling the aperture disk.
     Ray GetRay(float s, float t, RNG& rng, Vec3* cam_forward = nullptr) const {
         float ray_time = shutter_open_ + rng.UniformFloat() * (shutter_close_ - shutter_open_);
         const CameraFrame frame =
-            animated_ ? BuildFrame(timeline_.Evaluate(ray_time), aspect_ratio_) : static_frame_;
+            animated_ ? InterpolateFrame(ray_time) : static_frame_;
         if (cam_forward != nullptr) {
             *cam_forward = -frame.w;
         }
@@ -173,12 +180,57 @@ class Camera {
         return frame;
     }
 
+    // Interpolate between two precomputed keyframe frames, applying the easing curve.
+    // Avoids per-ray BuildFrame overhead (tan, sqrt, cross) for animated cameras.
+    CameraFrame InterpolateFrame(float t) const {
+        const auto& kfs = timeline_.keyframes;
+        const float first_time = kfs.front().time;
+        const float last_time = kfs.back().time;
+        if (t <= first_time) return keyframe_frames_.front();
+        if (t >= last_time) return keyframe_frames_.back();
+
+        auto it = std::upper_bound(kfs.begin(), kfs.end(), t,
+                                   [](float time, const CameraKeyframe& k) {
+                                       return time < k.time;
+                                   });
+        size_t i = static_cast<size_t>(std::distance(kfs.begin(), it)) - 1;
+
+        const CameraKeyframe& k0 = kfs[i];
+        const CameraKeyframe& k1 = kfs[i + 1];
+        float dt = k1.time - k0.time;
+        if (dt <= 1e-20f) return keyframe_frames_[i + 1];
+
+        float local_u = std::clamp((t - k0.time) / dt, 0.0f, 1.0f);
+        float alpha = k1.curve ? k1.curve->Evaluate(local_u)
+                               : BezierCurve::Linear().Evaluate(local_u);
+
+        const CameraFrame& f0 = keyframe_frames_[i];
+        const CameraFrame& f1 = keyframe_frames_[i + 1];
+
+        CameraFrame out;
+        out.origin = LerpVec3(f0.origin, f1.origin, alpha);
+        out.lower_left_corner = LerpVec3(f0.lower_left_corner, f1.lower_left_corner, alpha);
+        out.horizontal = LerpVec3(f0.horizontal, f1.horizontal, alpha);
+        out.vertical = LerpVec3(f0.vertical, f1.vertical, alpha);
+        out.u = Normalize(LerpVec3(f0.u, f1.u, alpha));
+        out.v = Normalize(LerpVec3(f0.v, f1.v, alpha));
+        out.w = Normalize(LerpVec3(f0.w, f1.w, alpha));
+        out.lens_radius = f0.lens_radius + (f1.lens_radius - f0.lens_radius) * alpha;
+        return out;
+    }
+
+    static Vec3 LerpVec3(const Vec3& a, const Vec3& b, float t) {
+        return a + (b - a) * t;
+    }
+
     CameraTimeline timeline_;
     float aspect_ratio_ = 1.0f;
     float shutter_open_ = 0.0f;
     float shutter_close_ = 0.0f;
     bool animated_ = false;
     CameraFrame static_frame_;
+    // Precomputed frames at each keyframe time; lerped between in InterpolateFrame().
+    std::vector<CameraFrame> keyframe_frames_;
 };
 
 }  // namespace skwr

--- a/skewer/src/session/render_session.cc
+++ b/skewer/src/session/render_session.cc
@@ -124,9 +124,8 @@ static void RenderLayerPass(const SceneConfig& config, const std::string& layer_
 
     float aspect =
         static_cast<float>(opts.image_config.width) / static_cast<float>(opts.image_config.height);
-    auto cam = std::make_unique<Camera>(config.look_from, config.look_at, config.vup, config.vfov,
-                                        aspect, config.aperture_radius, config.focus_distance,
-                                        shutter_open, shutter_close);
+    auto cam =
+        std::make_unique<Camera>(config.camera_timeline, aspect, shutter_open, shutter_close);
     ic.cam_w = -cam->GetW();
 
     auto film = std::make_unique<Film>(opts.image_config.width, opts.image_config.height);
@@ -169,6 +168,7 @@ void RenderSession::RenderScene(const std::string& scene_file, const RenderCliOp
     cam_vfov_ = config.vfov;
     cam_aperture_ = config.aperture_radius;
     cam_focus_dist_ = config.focus_distance;
+    cam_timeline_ = config.camera_timeline;
     if (config.animation) {
         cam_shutter_open_ = config.animation->start;
         cam_shutter_close_ = config.animation->start;
@@ -216,7 +216,10 @@ void RenderSession::RenderScene(const std::string& scene_file, const RenderCliOp
                       << "\" omits \"animated\"; defaulting to false.\n";
         }
 
-        if (anim_flags.animated) {
+        const bool layer_frame_varying =
+            anim_flags.animated || (config.animation && config.camera_timeline.IsAnimated());
+
+        if (layer_frame_varying) {
             if (cli.statics_only) {
                 continue;
             }
@@ -281,8 +284,8 @@ void RenderSession::RenderFrame(const std::string& scene_file, const std::string
     }
 
     LayerAnimationFlags anim_flags = PeekLayerAnimationFlags(matched);
-    if (!anim_flags.animated) {
-        throw std::runtime_error("RenderFrame target layer is not marked animated: " + matched);
+    if (!anim_flags.animated && !config.camera_timeline.IsAnimated()) {
+        throw std::runtime_error("RenderFrame target layer is not frame-varying: " + matched);
     }
 
     const bool multi_layer = config.layer_paths.size() > 1;
@@ -314,11 +317,17 @@ void RenderSession::LoadLayerDirect(const std::string& layer_file, Vec3 look_fro
     cam_look_at_ = look_at;
     cam_vup_ = vup;
     cam_vfov_ = vfov;
+    cam_timeline_.base.look_from = look_from;
+    cam_timeline_.base.look_at = look_at;
+    cam_timeline_.base.vup = vup;
+    cam_timeline_.base.vfov = vfov;
+    cam_timeline_.base.aperture_radius = cam_aperture_;
+    cam_timeline_.base.focus_distance = cam_focus_dist_;
+    cam_timeline_.keyframes.clear();
 
     float aspect = static_cast<float>(options_.image_config.width) /
                    static_cast<float>(options_.image_config.height);
-    camera_ = std::make_unique<Camera>(cam_look_from_, cam_look_at_, cam_vup_, cam_vfov_, aspect,
-                                       cam_aperture_, cam_focus_dist_);
+    camera_ = std::make_unique<Camera>(cam_timeline_, aspect);
 
     film_ = std::make_unique<Film>(options_.image_config.width, options_.image_config.height);
     integrator_ = CreateIntegrator(options_.integrator_type);
@@ -372,13 +381,13 @@ void RenderSession::LoadSceneFromFile(const std::string& scene_file, int thread_
     cam_focus_dist_ = config.focus_distance;
     cam_shutter_open_ = config.shutter_open;
     cam_shutter_close_ = config.shutter_close;
+    cam_timeline_ = config.camera_timeline;
 
     // 6. Create camera (aspect ratio derived from image dimensions)
     float aspect = static_cast<float>(options_.image_config.width) /
                    static_cast<float>(options_.image_config.height);
-    camera_ = std::make_unique<Camera>(cam_look_from_, cam_look_at_, cam_vup_, cam_vfov_, aspect,
-                                       cam_aperture_, cam_focus_dist_, cam_shutter_open_,
-                                       cam_shutter_close_);
+    camera_ =
+        std::make_unique<Camera>(cam_timeline_, aspect, cam_shutter_open_, cam_shutter_close_);
 
     // 7. Create film and integrator
     film_ = std::make_unique<Film>(options_.image_config.width, options_.image_config.height);
@@ -402,9 +411,8 @@ void RenderSession::RebuildFilm() {
     // the projection matches the new film dimensions.
     float aspect = static_cast<float>(options_.image_config.width) /
                    static_cast<float>(options_.image_config.height);
-    camera_ = std::make_unique<Camera>(cam_look_from_, cam_look_at_, cam_vup_, cam_vfov_, aspect,
-                                       cam_aperture_, cam_focus_dist_, cam_shutter_open_,
-                                       cam_shutter_close_);
+    camera_ =
+        std::make_unique<Camera>(cam_timeline_, aspect, cam_shutter_open_, cam_shutter_close_);
     options_.integrator_config.cam_w = -camera_->GetW();
 
     film_ = std::make_unique<Film>(options_.image_config.width, options_.image_config.height);

--- a/skewer/src/session/render_session.h
+++ b/skewer/src/session/render_session.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "film/film.h"
+#include "scene/camera.h"
 #include "session/render_options.h"
 
 /*
@@ -88,6 +89,7 @@ class RenderSession {
     float cam_focus_dist_ = 1.0f;
     float cam_shutter_open_ = 0.0f;
     float cam_shutter_close_ = 0.0f;
+    CameraTimeline cam_timeline_;
 };
 
 }  // namespace skwr

--- a/skewer/tests/unit/test_motion_blur.cc
+++ b/skewer/tests/unit/test_motion_blur.cc
@@ -36,6 +36,62 @@ TEST(MotionBlur, CameraZeroShutterAllRaysSameTime) {
     }
 }
 
+TEST(CameraAnimation, TimelineCarriesForwardAndInterpolatesOptics) {
+    CameraTimeline timeline;
+    timeline.base.look_from = Vec3(0.0f, 0.0f, 0.0f);
+    timeline.base.look_at = Vec3(0.0f, 0.0f, -1.0f);
+    timeline.base.vup = Vec3(0.0f, 1.0f, 0.0f);
+    timeline.base.vfov = 40.0f;
+    timeline.base.aperture_radius = 0.1f;
+    timeline.base.focus_distance = 2.0f;
+
+    CameraKeyframe k0;
+    k0.time = 0.0f;
+    k0.state = timeline.base;
+    CameraKeyframe k1;
+    k1.time = 2.0f;
+    k1.state = k0.state;
+    k1.state.look_from = Vec3(4.0f, 0.0f, 0.0f);
+    k1.state.aperture_radius = 0.5f;
+    k1.state.focus_distance = 6.0f;
+    timeline.keyframes = {k0, k1};
+
+    CameraState mid = timeline.Evaluate(1.0f);
+    EXPECT_NEAR(mid.look_from.x(), 2.0f, 1e-5f);
+    EXPECT_NEAR(mid.look_at.z(), -1.0f, 1e-5f);
+    EXPECT_NEAR(mid.aperture_radius, 0.3f, 1e-5f);
+    EXPECT_NEAR(mid.focus_distance, 4.0f, 1e-5f);
+}
+
+TEST(CameraAnimation, RayOriginUsesPoseAtSampledTime) {
+    CameraTimeline timeline;
+    timeline.base.look_from = Vec3(0.0f, 0.0f, 0.0f);
+    timeline.base.look_at = Vec3(0.0f, 0.0f, -1.0f);
+    timeline.base.vup = Vec3(0.0f, 1.0f, 0.0f);
+    timeline.base.vfov = 60.0f;
+    timeline.base.aperture_radius = 0.0f;
+    timeline.base.focus_distance = 1.0f;
+
+    CameraKeyframe k0;
+    k0.time = 0.0f;
+    k0.state = timeline.base;
+    CameraKeyframe k1;
+    k1.time = 1.0f;
+    k1.state = k0.state;
+    k1.state.look_from = Vec3(10.0f, 0.0f, 0.0f);
+    k1.state.look_at = Vec3(10.0f, 0.0f, -1.0f);
+    timeline.keyframes = {k0, k1};
+
+    Camera cam(timeline, 1.0f, 0.0f, 1.0f);
+    RNG rng(0, 123);
+    Vec3 cam_forward;
+    Ray r = cam.GetRay(0.5f, 0.5f, rng, &cam_forward);
+
+    EXPECT_GT(r.origin().x(), 0.0f);
+    EXPECT_LT(r.origin().x(), 10.0f);
+    EXPECT_NEAR(cam_forward.z(), -1.0f, 1e-4f);
+}
+
 TEST(MotionBlur, TRSInverseApplyRoundTripPoint) {
     TRS trs =
         TRSFromEuler(Vec3(1.0f, 2.0f, 3.0f), Vec3(10.0f, 20.0f, 30.0f), Vec3(2.0f, 2.0f, 2.0f));

--- a/skewer/tests/unit/test_scene_graph.cc
+++ b/skewer/tests/unit/test_scene_graph.cc
@@ -86,6 +86,62 @@ TEST(GraphJson, ParseAnimatedTransformKeyframes) {
     EXPECT_NEAR(mid.translation.x(), 0.5f, 1e-5f);
 }
 
+TEST(SceneLoader, ParseCameraKeyframes) {
+    std::filesystem::path p =
+        std::filesystem::temp_directory_path() / "skewer_ut_camera_keyframes_scene.json";
+    {
+        std::ofstream out(p);
+        out << R"({
+  "camera": {
+    "look_from": [0, 0, 4],
+    "look_at": [0, 0, 0],
+    "vup": [0, 1, 0],
+    "vfov": 50,
+    "aperture_radius": 0.1,
+    "focus_distance": 4,
+    "keyframes": [
+      { "time": 0, "look_from": [0, 0, 4] },
+      { "time": 2, "look_from": [2, 0, 4], "focus_distance": 8, "aperture_radius": 0.5 }
+    ]
+  },
+  "animation": { "start": 0, "end": 2, "fps": 24, "shutter_angle": 180 },
+  "layers": ["layer.json"]
+})";
+    }
+
+    SceneConfig config = LoadSceneFile(p.string());
+    ASSERT_EQ(config.camera_timeline.keyframes.size(), 2u);
+    EXPECT_TRUE(config.camera_timeline.IsAnimated());
+    CameraState mid = config.camera_timeline.Evaluate(1.0f);
+    EXPECT_NEAR(mid.look_from.x(), 1.0f, 1e-5f);
+    EXPECT_NEAR(mid.look_at.z(), 0.0f, 1e-5f);
+    EXPECT_NEAR(mid.focus_distance, 6.0f, 1e-5f);
+    EXPECT_NEAR(mid.aperture_radius, 0.3f, 1e-5f);
+    std::filesystem::remove(p);
+}
+
+TEST(SceneLoader, RejectInvalidCameraKeyframeOptics) {
+    std::filesystem::path p =
+        std::filesystem::temp_directory_path() / "skewer_ut_bad_camera_keyframes_scene.json";
+    {
+        std::ofstream out(p);
+        out << R"({
+  "camera": {
+    "look_from": [0, 0, 4],
+    "look_at": [0, 0, 0],
+    "keyframes": [
+      { "time": 0 },
+      { "time": 1, "aperture_radius": -1 }
+    ]
+  },
+  "layers": ["layer.json"]
+})";
+    }
+
+    EXPECT_THROW(LoadSceneFile(p.string()), std::runtime_error);
+    std::filesystem::remove(p);
+}
+
 TEST(SceneGraph, LoadLayerQuadFromFile) {
     std::filesystem::path p =
         std::filesystem::temp_directory_path() / "skewer_ut_scene_graph_layer.json";

--- a/skewer/tests/unit/test_scene_graph.cc
+++ b/skewer/tests/unit/test_scene_graph.cc
@@ -112,6 +112,8 @@ TEST(SceneLoader, ParseCameraKeyframes) {
     SceneConfig config = LoadSceneFile(p.string());
     ASSERT_EQ(config.camera_timeline.keyframes.size(), 2u);
     EXPECT_TRUE(config.camera_timeline.IsAnimated());
+    EXPECT_EQ(config.camera_timeline.keyframes[0].curve, nullptr);
+    EXPECT_EQ(config.camera_timeline.keyframes[1].curve, nullptr);
     CameraState mid = config.camera_timeline.Evaluate(1.0f);
     EXPECT_NEAR(mid.look_from.x(), 1.0f, 1e-5f);
     EXPECT_NEAR(mid.look_at.z(), 0.0f, 1e-5f);
@@ -132,6 +134,28 @@ TEST(SceneLoader, RejectInvalidCameraKeyframeOptics) {
     "keyframes": [
       { "time": 0 },
       { "time": 1, "aperture_radius": -1 }
+    ]
+  },
+  "layers": ["layer.json"]
+})";
+    }
+
+    EXPECT_THROW(LoadSceneFile(p.string()), std::runtime_error);
+    std::filesystem::remove(p);
+}
+
+TEST(SceneLoader, RejectAnimatedCameraWithoutAnimationBlock) {
+    std::filesystem::path p = std::filesystem::temp_directory_path() /
+                              "skewer_ut_camera_keyframes_no_animation_scene.json";
+    {
+        std::ofstream out(p);
+        out << R"({
+  "camera": {
+    "look_from": [0, 0, 4],
+    "look_at": [0, 0, 0],
+    "keyframes": [
+      { "time": 0 },
+      { "time": 1, "look_from": [1, 0, 4] }
     ]
   },
   "layers": ["layer.json"]


### PR DESCRIPTION
- add camera timeline/keyframe support to the renderer, including animated pose, vfov, focus distance, and aperture radius
- sample camera state at primary-ray shutter time so camera motion blur and animated depth of field work per ray
- make cloud/API validation and coordinator layer modes aware that camera keyframes make every layer frame-varying
- round-trip camera keyframes in the previewer and evaluate them during viewport playback/scrubbing
- document the new scene-format camera keyframe contract
