### PR TITLE
[bugfix] Fix Transparent Background Toggle

### DIFF
--- a/apps/scene-previewer/src/components/RenderSettingsPanel.tsx
+++ b/apps/scene-previewer/src/components/RenderSettingsPanel.tsx
@@ -277,19 +277,19 @@ export const RenderSettingsPanel = memo(function RenderSettingsPanel({
 						</div>
 					)}
 
-				{/* Transparent background checkbox */}
-				<div className={sb.toggleRow}>
-					<span className={u.kvKey}>Transparent background</span>
-					<label className={sb.checkRow}>
-						<input
-							type="checkbox"
-							checked={settings.transparent_background === true}
-							onChange={(e) =>
-								patch({ transparent_background: e.target.checked || false })
-							}
-						/>
-					</label>
-				</div>
+					{/* Transparent background checkbox */}
+					<div className={sb.toggleRow}>
+						<span className={u.kvKey}>Transparent background</span>
+						<label className={sb.checkRow}>
+							<input
+								type="checkbox"
+								checked={settings.transparent_background === true}
+								onChange={(e) =>
+									patch({ transparent_background: e.target.checked || false })
+								}
+							/>
+						</label>
+					</div>
 				</div>
 			</Collapsible.Content>
 		</Collapsible.Root>

--- a/apps/scene-previewer/src/components/RenderSettingsPanel.tsx
+++ b/apps/scene-previewer/src/components/RenderSettingsPanel.tsx
@@ -265,15 +265,15 @@ export const RenderSettingsPanel = memo(function RenderSettingsPanel({
 								))}
 							</div>
 
-						<button
-							type="button"
-							className={sb.removeBtn}
-							onClick={removeSkybox}
-							title="Remove skybox"
-						>
-							<Trash2 size={12} strokeWidth={2} />
-							<span>Remove skybox</span>
-						</button>
+							<button
+								type="button"
+								className={sb.removeBtn}
+								onClick={removeSkybox}
+								title="Remove skybox"
+							>
+								<Trash2 size={12} strokeWidth={2} />
+								<span>Remove skybox</span>
+							</button>
 						</div>
 					)}
 

--- a/apps/scene-previewer/src/components/RenderSettingsPanel.tsx
+++ b/apps/scene-previewer/src/components/RenderSettingsPanel.tsx
@@ -265,17 +265,32 @@ export const RenderSettingsPanel = memo(function RenderSettingsPanel({
 								))}
 							</div>
 
-							<button
-								type="button"
-								className={sb.removeBtn}
-								onClick={removeSkybox}
-								title="Remove skybox"
-							>
-								<Trash2 size={12} strokeWidth={2} />
-								<span>Remove skybox</span>
-							</button>
+						<button
+							type="button"
+							className={sb.removeBtn}
+							onClick={removeSkybox}
+							title="Remove skybox"
+						>
+							<Trash2 size={12} strokeWidth={2} />
+							<span>Remove skybox</span>
+						</button>
 						</div>
 					)}
+
+					{/* Alpha / transparent background toggle */}
+					<div className={u.kvRow} style={{ marginTop: 8 }}>
+						<span className={u.kvKey}>alpha</span>
+						<label className={sb.checkRow}>
+							<input
+								type="checkbox"
+								checked={settings.transparent_background === true}
+								onChange={(e) =>
+									patch({ transparent_background: e.target.checked || false })
+								}
+							/>
+							<span>Transparent background</span>
+						</label>
+					</div>
 				</div>
 			</Collapsible.Content>
 		</Collapsible.Root>

--- a/apps/scene-previewer/src/components/RenderSettingsPanel.tsx
+++ b/apps/scene-previewer/src/components/RenderSettingsPanel.tsx
@@ -277,20 +277,19 @@ export const RenderSettingsPanel = memo(function RenderSettingsPanel({
 						</div>
 					)}
 
-					{/* Alpha / transparent background toggle */}
-					<div className={u.kvRow} style={{ marginTop: 8 }}>
-						<span className={u.kvKey}>alpha</span>
-						<label className={sb.checkRow}>
-							<input
-								type="checkbox"
-								checked={settings.transparent_background === true}
-								onChange={(e) =>
-									patch({ transparent_background: e.target.checked || false })
-								}
-							/>
-							<span>Transparent background</span>
-						</label>
-					</div>
+				{/* Transparent background checkbox */}
+				<div className={sb.toggleRow}>
+					<span className={u.kvKey}>Transparent background</span>
+					<label className={sb.checkRow}>
+						<input
+							type="checkbox"
+							checked={settings.transparent_background === true}
+							onChange={(e) =>
+								patch({ transparent_background: e.target.checked || false })
+							}
+						/>
+					</label>
+				</div>
 				</div>
 			</Collapsible.Content>
 		</Collapsible.Root>

--- a/apps/scene-previewer/src/components/SkyboxPanel.module.css
+++ b/apps/scene-previewer/src/components/SkyboxPanel.module.css
@@ -136,16 +136,21 @@
 	border-color: var(--t2);
 }
 
-/* ── Transparent background checkbox row ── */
+/* ── Transparent background toggle row ── */
+.toggleRow {
+	display: flex;
+	align-items: center;
+	gap: 18px;
+	padding: 2px 0;
+	margin-top: 10px;
+}
+
 .checkRow {
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	color: var(--t1);
-	font-size: 10.5px;
 	cursor: pointer;
 	user-select: none;
-	padding: 2px 0;
 }
 
 .checkRow input[type="checkbox"] {

--- a/apps/scene-previewer/src/components/SkyboxPanel.module.css
+++ b/apps/scene-previewer/src/components/SkyboxPanel.module.css
@@ -135,3 +135,22 @@
 	color: var(--t1);
 	border-color: var(--t2);
 }
+
+/* ── Transparent background checkbox row ── */
+.checkRow {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	color: var(--t1);
+	font-size: 10.5px;
+	cursor: pointer;
+	user-select: none;
+	padding: 2px 0;
+}
+
+.checkRow input[type="checkbox"] {
+	width: 13px;
+	height: 13px;
+	cursor: pointer;
+	accent-color: var(--amber);
+}

--- a/apps/scene-previewer/src/components/Viewport.tsx
+++ b/apps/scene-previewer/src/components/Viewport.tsx
@@ -1075,10 +1075,14 @@ export function Viewport({
 		const sc = threeScene.current;
 		if (!sc) return;
 
-		const hasSkybox = !!scene?.skybox;
+		const hasSkyboxFaces =
+			!!scene?.skybox &&
+			Object.values(scene.skybox.faces).some(
+				(p) => typeof p === "string" && p.trim() !== "",
+			);
 		const isTransparent = scene?.settings?.transparent_background === true;
 
-		if (hasSkybox) return; // Effect 2b handles skybox background
+		if (hasSkyboxFaces) return; // Effect 2b handles the skybox texture
 
 		if (isTransparent) {
 			// Lazily create the checkerboard canvas texture

--- a/apps/scene-previewer/src/components/Viewport.tsx
+++ b/apps/scene-previewer/src/components/Viewport.tsx
@@ -1087,18 +1087,21 @@ export function Viewport({
 				const canvas = document.createElement("canvas");
 				canvas.width = size;
 				canvas.height = size;
-				const ctx = canvas.getContext("2d")!;
-				ctx.fillStyle = "#111";
-				ctx.fillRect(0, 0, size, size);
-				ctx.fillStyle = "#222";
-				ctx.fillRect(0, 0, size / 4, size / 4);
-				ctx.fillRect(size / 2, 0, size / 4, size / 4);
-				ctx.fillRect(size / 4, size / 4, size / 4, size / 4);
-				ctx.fillRect(size * 3 / 4, size / 4, size / 4, size / 4);
-				ctx.fillRect(0, size / 2, size / 4, size / 4);
-				ctx.fillRect(size / 2, size / 2, size / 4, size / 4);
-				ctx.fillRect(size / 4, size * 3 / 4, size / 4, size / 4);
-				ctx.fillRect(size * 3 / 4, size * 3 / 4, size / 4, size / 4);
+				const ctx = canvas.getContext("2d");
+				if (ctx != null) {
+					ctx.fillStyle = "#111";
+					ctx.fillRect(0, 0, size, size);
+					ctx.fillStyle = "#222";
+					ctx.fillRect(0, 0, size / 4, size / 4);
+					ctx.fillRect(size / 2, 0, size / 4, size / 4);
+					ctx.fillRect(size / 4, size / 4, size / 4, size / 4);
+					ctx.fillRect((size * 3) / 4, size / 4, size / 4, size / 4);
+					ctx.fillRect(0, size / 2, size / 4, size / 4);
+					ctx.fillRect(size / 2, size / 2, size / 4, size / 4);
+					ctx.fillRect(size / 4, (size * 3) / 4, size / 4, size / 4);
+					ctx.fillRect((size * 3) / 4, (size * 3) / 4, size / 4, size / 4);
+				}
+
 				const tex = new THREE.CanvasTexture(canvas);
 				tex.wrapS = THREE.RepeatWrapping;
 				tex.wrapT = THREE.RepeatWrapping;

--- a/apps/scene-previewer/src/components/Viewport.tsx
+++ b/apps/scene-previewer/src/components/Viewport.tsx
@@ -414,6 +414,7 @@ export function Viewport({
 	const blobUrlsRef = useRef<string[]>([]);
 	const skyboxTextureRef = useRef<THREE.CubeTexture | null>(null);
 	const lastSkyboxJsonRef = useRef<string>("");
+	const checkerTextureRef = useRef<THREE.CanvasTexture | null>(null);
 	const composer = useRef<EffectComposer | null>(null);
 	const outlinePass = useRef<OutlinePass | null>(null);
 	const transformControls = useRef<TransformControls | null>(null);
@@ -884,6 +885,11 @@ export function Viewport({
 				oldSkybox.dispose();
 				skyboxTextureRef.current = null;
 			}
+			const oldChecker = checkerTextureRef.current;
+			if (oldChecker) {
+				oldChecker.dispose();
+				checkerTextureRef.current = null;
+			}
 			const comp = composer.current;
 			if (comp) {
 				for (const pass of comp.passes) {
@@ -1059,6 +1065,55 @@ export function Viewport({
 			abortController.abort();
 		};
 	}, [dirHandle, scene, requestRender]);
+
+	// --- Effect 2c: visual preview of transparent vs opaque background ---
+	// When transparent_background is true and no skybox is present, show a checkerboard
+	// pattern as the THREE scene background. Otherwise use dark gray.
+	// Skybox always takes precedence (handled by Effect 2b), so we return early if one
+	// is present.
+	useEffect(() => {
+		const sc = threeScene.current;
+		if (!sc) return;
+
+		const hasSkybox = !!scene?.skybox;
+		const isTransparent = scene?.settings?.transparent_background === true;
+
+		if (hasSkybox) return; // Effect 2b handles skybox background
+
+		if (isTransparent) {
+			// Lazily create the checkerboard canvas texture
+			if (!checkerTextureRef.current) {
+				const size = 32;
+				const canvas = document.createElement("canvas");
+				canvas.width = size;
+				canvas.height = size;
+				const ctx = canvas.getContext("2d")!;
+				ctx.fillStyle = "#111";
+				ctx.fillRect(0, 0, size, size);
+				ctx.fillStyle = "#222";
+				ctx.fillRect(0, 0, size / 4, size / 4);
+				ctx.fillRect(size / 2, 0, size / 4, size / 4);
+				ctx.fillRect(size / 4, size / 4, size / 4, size / 4);
+				ctx.fillRect(size * 3 / 4, size / 4, size / 4, size / 4);
+				ctx.fillRect(0, size / 2, size / 4, size / 4);
+				ctx.fillRect(size / 2, size / 2, size / 4, size / 4);
+				ctx.fillRect(size / 4, size * 3 / 4, size / 4, size / 4);
+				ctx.fillRect(size * 3 / 4, size * 3 / 4, size / 4, size / 4);
+				const tex = new THREE.CanvasTexture(canvas);
+				tex.wrapS = THREE.RepeatWrapping;
+				tex.wrapT = THREE.RepeatWrapping;
+				tex.repeat.set(64, 64);
+				tex.magFilter = THREE.NearestFilter;
+				tex.minFilter = THREE.NearestFilter;
+				tex.colorSpace = THREE.SRGBColorSpace;
+				checkerTextureRef.current = tex;
+			}
+			sc.background = checkerTextureRef.current;
+		} else {
+			sc.background = new THREE.Color(0x0c0d0f);
+		}
+		requestRender();
+	}, [scene?.settings?.transparent_background, scene?.skybox, requestRender]);
 
 	// --- Effect 3: update outline when selection changes ---
 	useEffect(() => {

--- a/docs/reference/scene-format.md
+++ b/docs/reference/scene-format.md
@@ -519,7 +519,7 @@ Each layer file can override render settings. The highest-priority render config
 | `noise_threshold`        | float  | `0`            | Adaptive sampling convergence threshold. `0` = disabled (always render to `max_samples`)                                                                                                              |
 | `adaptive_step`          | int    | `16`           | Samples between convergence checks when adaptive sampling is enabled                                                                                                                                  |
 | `enable_deep`            | bool   | `false`        | Enable deep pixel buffers (for compositing)                                                                                                                                                           |
-| `transparent_background` | bool   | `false`        | Missed primary rays produce alpha=0 instead of black. Required for clean layer compositing                                                                                                            |
+| `transparent_background` | bool   | `false` (`true` when scene has >1 layer) | Missed primary rays produce alpha=0 instead of black. Required for clean layer compositing                                                                                                            |
 | `visibility_depth`       | int    | `1`            | How many surface bounces to check for "covered" pixels when `transparent_background=true`. `1` = only direct camera visibility; higher values allow seeing visible objects through invisible surfaces |
 | `save_sample_map`        | bool   | `false`        | Write per-pixel sample count heatmap (debug)                                                                                                                                                          |
 | `image.width`            | int    | `800`          | Output image width in pixels                                                                                                                                                                          |
@@ -557,6 +557,22 @@ For multi-layer compositing, set `transparent_background: true`:
 - `visibility_depth` controls how many bounces are checked:
   - `1` (default): only objects directly visible from the camera count
   - `2-4`: allows visible objects seen through invisible surfaces (e.g., a visible sphere reflected in an invisible mirror)
+
+!!! warning "Multi-layer scenes default to `transparent_background: true`"
+    When a scene has more than one layer file, `transparent_background` defaults to `true`
+    automatically — even if not explicitly set — so layers can be composited together cleanly.
+
+    To render with an **opaque black background**, set `"transparent_background": false` in each
+    layer's `render` block:
+
+    ```json
+    "render": {
+      "transparent_background": false
+    }
+    ```
+
+    With `transparent_background: false`, the camera background (black void or skybox) becomes
+    fully opaque (alpha=1), giving you a solid background in the final render.
 
 ## Complete Example
 

--- a/skewer/src/io/scene_loader.cc
+++ b/skewer/src/io/scene_loader.cc
@@ -540,7 +540,9 @@ static RenderOptions ParseRenderOptions(const json& j) {
         opts.integrator_config.max_depth = GetOr(r, "max_depth", 50);
         opts.integrator_config.num_threads = GetOr(r, "threads", 0);
         opts.integrator_config.enable_deep = GetOr(r, "enable_deep", false);
-        opts.integrator_config.transparent_background = GetOr(r, "transparent_background", false);
+        if (r.contains("transparent_background")) {
+            opts.integrator_config.transparent_background = r["transparent_background"].get<bool>();
+        }
         opts.integrator_config.visibility_depth = GetOr(r, "visibility_depth", 1);
         opts.integrator_config.tile_size = GetOr(r, "tile_size", 32);
 

--- a/skewer/src/kernels/path_kernel.cc
+++ b/skewer/src/kernels/path_kernel.cc
@@ -84,7 +84,8 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
         // vol dispatch, sample medium with t_surface as upper bound
         if (scatter_medium) {
             ray_t += mi.t;
-            if (config.transparent_background.value_or(false) && vis_checks < config.visibility_depth) {
+            if (config.transparent_background.value_or(false) &&
+                vis_checks < config.visibility_depth) {
                 vis_checks++;
                 saw_visible = true;  // Participating media contribute layer coverage
             }
@@ -154,7 +155,8 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
             }
 
             const Material& mat = scene.GetMaterial(si.material_id);
-            if (config.transparent_background.value_or(false) && vis_checks < config.visibility_depth) {
+            if (config.transparent_background.value_or(false) &&
+                vis_checks < config.visibility_depth) {
                 vis_checks++;
                 if (mat.visible) saw_visible = true;
             }
@@ -269,7 +271,8 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
                 break;
             }
         } else {
-            if (config.transparent_background.value_or(false) && vis_checks < config.visibility_depth) {
+            if (config.transparent_background.value_or(false) &&
+                vis_checks < config.visibility_depth) {
                 vis_checks++;
                 // Environment hit = no visible object along this path segment
             }
@@ -311,7 +314,9 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
 
     dpr.ResolveToDeep(writer, ray, primary_cam_w, wl);
     const float out_alpha =
-        (config.transparent_background.value_or(false) && !saw_visible && !hit_opaque_background) ? 0.0f : 1.0f;
+        (config.transparent_background.value_or(false) && !saw_visible && !hit_opaque_background)
+            ? 0.0f
+            : 1.0f;
     writer.WriteBeauty(SpectrumToRGB(L, wl), out_alpha);
     writer.FlushDeepSegments();
 }

--- a/skewer/src/kernels/path_kernel.cc
+++ b/skewer/src/kernels/path_kernel.cc
@@ -64,6 +64,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
     bool saw_visible = false;
     bool hit_opaque_background = false;
     int vis_checks = 0;
+    const bool transparent_bg = config.transparent_background.value_or(false);
 
     for (int depth = 0; depth < config.max_depth; ++depth) {  // TODO: switch to while?
         SurfaceInteraction si;
@@ -84,7 +85,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
         // vol dispatch, sample medium with t_surface as upper bound
         if (scatter_medium) {
             ray_t += mi.t;
-            if (config.transparent_background.value_or(false) &&
+            if (transparent_bg &&
                 vis_checks < config.visibility_depth) {
                 vis_checks++;
                 saw_visible = true;  // Participating media contribute layer coverage
@@ -155,7 +156,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
             }
 
             const Material& mat = scene.GetMaterial(si.material_id);
-            if (config.transparent_background.value_or(false) &&
+            if (transparent_bg &&
                 vis_checks < config.visibility_depth) {
                 vis_checks++;
                 if (mat.visible) saw_visible = true;
@@ -271,7 +272,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
                 break;
             }
         } else {
-            if (config.transparent_background.value_or(false) &&
+            if (transparent_bg &&
                 vis_checks < config.visibility_depth) {
                 vis_checks++;
                 // Environment hit = no visible object along this path segment
@@ -294,7 +295,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
             dpr.AppendVertex(RenderConstants::kFarClip, RenderConstants::kFarClip, env_L, 1.0f,
                              is_camera_path, false);
             L += env_L * current_beta;
-            if (!config.transparent_background.value_or(false)) {
+            if (!transparent_bg) {
                 hit_opaque_background = true;
             }
             break;
@@ -314,7 +315,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
 
     dpr.ResolveToDeep(writer, ray, primary_cam_w, wl);
     const float out_alpha =
-        (config.transparent_background.value_or(false) && !saw_visible && !hit_opaque_background)
+        (transparent_bg && !saw_visible && !hit_opaque_background)
             ? 0.0f
             : 1.0f;
     writer.WriteBeauty(SpectrumToRGB(L, wl), out_alpha);

--- a/skewer/src/kernels/path_kernel.cc
+++ b/skewer/src/kernels/path_kernel.cc
@@ -84,7 +84,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
         // vol dispatch, sample medium with t_surface as upper bound
         if (scatter_medium) {
             ray_t += mi.t;
-            if (config.transparent_background && vis_checks < config.visibility_depth) {
+            if (config.transparent_background.value_or(false) && vis_checks < config.visibility_depth) {
                 vis_checks++;
                 saw_visible = true;  // Participating media contribute layer coverage
             }
@@ -154,7 +154,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
             }
 
             const Material& mat = scene.GetMaterial(si.material_id);
-            if (config.transparent_background && vis_checks < config.visibility_depth) {
+            if (config.transparent_background.value_or(false) && vis_checks < config.visibility_depth) {
                 vis_checks++;
                 if (mat.visible) saw_visible = true;
             }
@@ -269,7 +269,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
                 break;
             }
         } else {
-            if (config.transparent_background && vis_checks < config.visibility_depth) {
+            if (config.transparent_background.value_or(false) && vis_checks < config.visibility_depth) {
                 vis_checks++;
                 // Environment hit = no visible object along this path segment
             }
@@ -291,6 +291,9 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
             dpr.AppendVertex(RenderConstants::kFarClip, RenderConstants::kFarClip, env_L, 1.0f,
                              is_camera_path, false);
             L += env_L * current_beta;
+            if (!config.transparent_background.value_or(false)) {
+                hit_opaque_background = true;
+            }
             break;
         }
 
@@ -308,7 +311,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
 
     dpr.ResolveToDeep(writer, ray, primary_cam_w, wl);
     const float out_alpha =
-        (config.transparent_background && !saw_visible && !hit_opaque_background) ? 0.0f : 1.0f;
+        (config.transparent_background.value_or(false) && !saw_visible && !hit_opaque_background) ? 0.0f : 1.0f;
     writer.WriteBeauty(SpectrumToRGB(L, wl), out_alpha);
     writer.FlushDeepSegments();
 }

--- a/skewer/src/kernels/path_kernel.cc
+++ b/skewer/src/kernels/path_kernel.cc
@@ -85,8 +85,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
         // vol dispatch, sample medium with t_surface as upper bound
         if (scatter_medium) {
             ray_t += mi.t;
-            if (transparent_bg &&
-                vis_checks < config.visibility_depth) {
+            if (transparent_bg && vis_checks < config.visibility_depth) {
                 vis_checks++;
                 saw_visible = true;  // Participating media contribute layer coverage
             }
@@ -156,8 +155,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
             }
 
             const Material& mat = scene.GetMaterial(si.material_id);
-            if (transparent_bg &&
-                vis_checks < config.visibility_depth) {
+            if (transparent_bg && vis_checks < config.visibility_depth) {
                 vis_checks++;
                 if (mat.visible) saw_visible = true;
             }
@@ -272,8 +270,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
                 break;
             }
         } else {
-            if (transparent_bg &&
-                vis_checks < config.visibility_depth) {
+            if (transparent_bg && vis_checks < config.visibility_depth) {
                 vis_checks++;
                 // Environment hit = no visible object along this path segment
             }
@@ -315,9 +312,7 @@ void Li(const Ray& ray, const Scene& scene, RNG& rng, const IntegratorConfig& co
 
     dpr.ResolveToDeep(writer, ray, primary_cam_w, wl);
     const float out_alpha =
-        (transparent_bg && !saw_visible && !hit_opaque_background)
-            ? 0.0f
-            : 1.0f;
+        (transparent_bg && !saw_visible && !hit_opaque_background) ? 0.0f : 1.0f;
     writer.WriteBeauty(SpectrumToRGB(L, wl), out_alpha);
     writer.FlushDeepSegments();
 }

--- a/skewer/src/session/render_options.h
+++ b/skewer/src/session/render_options.h
@@ -1,6 +1,7 @@
 #ifndef SKWR_SESSION_RENDER_OPTIONS_H_
 #define SKWR_SESSION_RENDER_OPTIONS_H_
 
+#include <optional>
 #include <string>
 
 #include "core/math/vec3.h"
@@ -28,7 +29,8 @@ struct IntegratorConfig {
     bool enable_deep = false;
     // When true, primary rays that miss all geometry produce alpha=0 instead of
     // opaque black. Enables clean layer compositing without a black background matte.
-    bool transparent_background = false;
+    // nullopt = not explicitly set by the user (renderer may apply a default).
+    std::optional<bool> transparent_background;
 
     // How many surface bounces are checked when deciding if a pixel is "covered"
     // by a visible object. Only meaningful when transparent_background=true.

--- a/skewer/src/session/render_session.cc
+++ b/skewer/src/session/render_session.cc
@@ -119,7 +119,9 @@ static void RenderLayerPass(const SceneConfig& config, const std::string& layer_
 
     if (multi_layer) {
         ic.enable_deep = true;
-        ic.transparent_background = true;
+        if (!ic.transparent_background.has_value()) {
+            ic.transparent_background = true;
+        }
     }
     if (thread_override > 0) ic.num_threads = thread_override;
 


### PR DESCRIPTION
For multi-layer scenes, the renderer sets on transparent backgrounds (which is intended) by default, but then there was no way to bring back opaque backgrounds because opacity was forced to 0. Therefore the `trasparent_background` option in any json layer didn't do anything. This should fix that issue.

https://github.com/user-attachments/assets/06650fc8-c4d7-42de-9e12-5a306b506fc3