### PR TITLE
[feat] Windows Optimizations

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -168,7 +168,7 @@ jobs:
         shell: cmd
         run: |
           call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake --preset release-portable -G Ninja -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows
+          cmake --preset release-portable -G Ninja -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DSKEWER_BUILD_NATIVE_OPTIMIZATIONS=ON
           cmake --build --preset release-portable --target skewer-render loom --parallel
           cmake --install build\release-portable --prefix "dist\stage\%ARTIFACT_NAME%" --component Runtime
           powershell -NoProfile -ExecutionPolicy Bypass -File scripts\bundle-release.ps1 -StageDir "dist\stage\%ARTIFACT_NAME%" -ArtifactName "%ARTIFACT_NAME%" -DistDir dist

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -63,5 +63,6 @@ The previewer viewport does provide interactive Three.js `OrbitControls` (orbit,
 
 - **No pre-built binaries:** Source build is required. No pre-compiled releases are available.
 - **Toolchain requirements:** C++20 compiler, CMake 3.21+, Go 1.21+, protoc, and several system libraries (OpenEXR, Imath, Zlib, libpng).
-- **Platform-specific optimizations:** Native CPU optimizations (`-march=znver3a`) only apply on Linux x86_64. Other platforms use a generic build.
-- **Windows:** MSVC CRT conflict workaround required (`gtest_force_shared_crt`). Some flags (e.g., `-ffast-math`) are Clang/GCC-only.
+- **Platform-specific optimizations:** Native CPU tunings (`-march=znver3`) only apply on Linux x86_64. Other platforms use a generic build.
+- **Windows AVX2 requirement:** Pre-built Windows binaries are compiled with `/arch:AVX2` and require a CPU with AVX2 support (Intel Haswell 2013+ / AMD Excavator 2015+). If building from source on older hardware, pass `-DSKEWER_BUILD_NATIVE_OPTIMIZATIONS=OFF` to CMake. Systems without AVX2 must build from source.
+- **Windows CRT conflict:** MSVC CRT conflict workaround required (`gtest_force_shared_crt`) when building with tests.

--- a/skewer/CMakeLists.txt
+++ b/skewer/CMakeLists.txt
@@ -81,19 +81,19 @@ target_include_directories(skewer-worker
         ${CMAKE_BINARY_DIR}
 )
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-  set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/io/scene_loader.cc" PROPERTIES
-      COMPILE_OPTIONS "-fno-fast-math"
-  )
-  set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/io/graph_from_json.cc" PROPERTIES
-      COMPILE_OPTIONS "-fno-fast-math"
-  )
-elseif(MSVC)
+if(MSVC)
   set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/io/scene_loader.cc" PROPERTIES
       COMPILE_OPTIONS "/fp:precise"
   )
   set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/io/graph_from_json.cc" PROPERTIES
       COMPILE_OPTIONS "/fp:precise"
+  )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+  set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/io/scene_loader.cc" PROPERTIES
+      COMPILE_OPTIONS "-fno-fast-math"
+  )
+  set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/io/graph_from_json.cc" PROPERTIES
+      COMPILE_OPTIONS "-fno-fast-math"
   )
 endif()
 
@@ -118,12 +118,16 @@ target_link_libraries(skewer-worker
 # Enable NanoVDB SIMD optimizations
 target_compile_definitions(skewer-worker PRIVATE NANOVDB_USE_INTRINSICS)
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+if(MSVC)
+  target_compile_options(skewer-render PRIVATE /fp:fast)
+  target_compile_options(skewer-worker PRIVATE /fp:fast)
+  if(SKEWER_BUILD_NATIVE_OPTIMIZATIONS)
+    target_compile_options(skewer-render PRIVATE /arch:AVX2)
+    target_compile_options(skewer-worker PRIVATE /arch:AVX2)
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   target_compile_options(skewer-render PRIVATE -ffast-math)
     target_compile_options(skewer-worker PRIVATE -ffast-math)
-elseif(MSVC)
-  target_compile_options(skewer-render PRIVATE /fp:fast /arch:AVX2)
-  target_compile_options(skewer-worker PRIVATE /fp:fast /arch:AVX2)
 endif()
 
 if(SKEWER_BUILD_NATIVE_OPTIMIZATIONS)

--- a/skewer/CMakeLists.txt
+++ b/skewer/CMakeLists.txt
@@ -88,6 +88,13 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/io/graph_from_json.cc" PROPERTIES
       COMPILE_OPTIONS "-fno-fast-math"
   )
+elseif(MSVC)
+  set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/io/scene_loader.cc" PROPERTIES
+      COMPILE_OPTIONS "/fp:precise"
+  )
+  set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/io/graph_from_json.cc" PROPERTIES
+      COMPILE_OPTIONS "/fp:precise"
+  )
 endif()
 
 # Link libraries
@@ -114,6 +121,9 @@ target_compile_definitions(skewer-worker PRIVATE NANOVDB_USE_INTRINSICS)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   target_compile_options(skewer-render PRIVATE -ffast-math)
     target_compile_options(skewer-worker PRIVATE -ffast-math)
+elseif(MSVC)
+  target_compile_options(skewer-render PRIVATE /fp:fast /arch:AVX2)
+  target_compile_options(skewer-worker PRIVATE /fp:fast /arch:AVX2)
 endif()
 
 if(SKEWER_BUILD_NATIVE_OPTIMIZATIONS)


### PR DESCRIPTION
The Windows build is missing two critical optimization flags that Clang/GCC on macOS/Unix get by default:
1. No `/fp:fast` (equivalent of `-ffast-math`)
- The Unix build applies `-ffast-math` to skewer-render and skewer-worker in `skewer/CMakeLists.txt`
2. No `/arch:AVX2`
- Neither MSVC nor Clang-on-Windows gets an architecture flag. On Unix, Clang auto-detects the host CPU and enables SSE/AVX when available. On MSVC, the default target is SSE2-only unless you explicitly pass `/arch:AVX2`. This means the rgb2spec fast SSE/AVX path and any compiler auto-vectorization use the lowest common denominator.