### PR TITLE
[bugfix] Fix release publish repo context

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -230,6 +230,7 @@ jobs:
     if: github.ref_type == 'tag'
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
 
     steps:
       - name: Download release artifacts


### PR DESCRIPTION
## Summary

- Set `GH_REPO` in the release publish job so GitHub CLI commands know which repository to operate on.

## Root Cause

The publish job downloads artifacts but does not check out the repository, so there is no `.git` directory for `gh release view/create/upload` to use when inferring the repo. `gh release view` hides that failure behind stderr redirection, then `gh release create --verify-tag` surfaces it as `fatal: not a git repository`.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-binaries.yml"); puts "yaml ok"'`