### PR TITLE
[feat] more previewer tests

### DIFF
--- a/apps/scene-previewer/test/components/viewport.test.tsx
+++ b/apps/scene-previewer/test/components/viewport.test.tsx
@@ -1,0 +1,242 @@
+import { createRef } from "react";
+import * as THREE from "three";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "vitest-browser-react";
+import { Viewport, type ViewportHandle } from "../../src/components/Viewport";
+import type { ResolvedScene } from "../../src/types/scene";
+import {
+	asDirectoryHandle,
+	MemoryDirectoryHandle,
+} from "../services/test-utils";
+
+const mocks = vi.hoisted(() => {
+	return {
+		buildSceneGraph: vi.fn(),
+		buildSkyboxTexture: vi.fn(),
+		revokeBlobUrls: vi.fn(),
+	};
+});
+
+vi.mock("../../src/services/scene-to-three", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../src/services/scene-to-three")>();
+	return {
+		...actual,
+		buildSceneGraph: mocks.buildSceneGraph,
+		buildSkyboxTexture: mocks.buildSkyboxTexture,
+		revokeBlobUrls: mocks.revokeBlobUrls,
+	};
+});
+
+vi.mock("three", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("three")>();
+	class FakeWebGLRenderer {
+		readonly domElement = document.createElement("canvas");
+		setPixelRatio() {}
+		setSize() {}
+		dispose() {}
+	}
+	return { ...actual, WebGLRenderer: FakeWebGLRenderer };
+});
+
+vi.mock("three/examples/jsm/controls/OrbitControls.js", () => {
+	class OrbitControls extends THREE.EventDispatcher {
+		target = new THREE.Vector3();
+		enableDamping = false;
+		dampingFactor = 0;
+		enabled = true;
+		update() {
+			return false;
+		}
+		dispose() {}
+	}
+	return { OrbitControls };
+});
+
+vi.mock("three/examples/jsm/controls/TransformControls.js", () => {
+	class TransformControls extends THREE.EventDispatcher {
+		enabled = true;
+		private helper = new THREE.Group();
+		addEventListener = super.addEventListener;
+		removeEventListener = super.removeEventListener;
+		attach() {}
+		detach() {}
+		dispose() {}
+		getHelper() {
+			return this.helper;
+		}
+		setMode() {}
+		setSize() {}
+		setSpace() {}
+	}
+	return { TransformControls };
+});
+
+vi.mock("three/examples/jsm/postprocessing/EffectComposer.js", () => {
+	class EffectComposer {
+		passes: unknown[] = [];
+		renderTarget1 = { dispose: vi.fn() };
+		renderTarget2 = { dispose: vi.fn() };
+		addPass(pass: unknown) {
+			this.passes.push(pass);
+		}
+		setSize() {}
+		render() {}
+		dispose() {}
+	}
+	return { EffectComposer };
+});
+
+vi.mock("three/examples/jsm/postprocessing/OutlinePass.js", () => {
+	class OutlinePass {
+		selectedObjects: THREE.Object3D[] = [];
+		visibleEdgeColor = { set: vi.fn() };
+		hiddenEdgeColor = { set: vi.fn() };
+		edgeStrength = 0;
+		edgeGlow = 0;
+		edgeThickness = 0;
+		pulsePeriod = 0;
+		dispose() {}
+	}
+	return { OutlinePass };
+});
+
+vi.mock("three/examples/jsm/postprocessing/RenderPass.js", () => {
+	class RenderPass {
+		dispose() {}
+	}
+	return { RenderPass };
+});
+
+vi.mock("three/examples/jsm/postprocessing/OutputPass.js", () => {
+	class OutputPass {
+		dispose() {}
+	}
+	return { OutputPass };
+});
+
+function makeScene(): ResolvedScene {
+	return {
+		camera: {
+			look_from: [0, 0, 5],
+			look_at: [0, 0, 0],
+			vup: [0, 1, 0],
+			vfov: 45,
+			aperture_radius: 0,
+			focus_distance: 5,
+		},
+		contexts: [],
+		layers: [],
+		output_dir: "renders",
+		animation: { start: 0, end: 0, fps: 24, shutter_angle: 180 },
+		settings: {
+			integrator: "path_trace",
+			max_samples: 64,
+			min_samples: 4,
+			max_depth: 6,
+			threads: 0,
+			image: { width: 640, height: 360 },
+		},
+	};
+}
+
+function makeBuiltGroup() {
+	const group = new THREE.Group();
+	const objectRoot = new THREE.Group();
+	objectRoot.userData.objectKey = "lyr:0:0";
+	const mesh = new THREE.Mesh(
+		new THREE.SphereGeometry(1, 8, 8),
+		new THREE.MeshBasicMaterial(),
+	);
+	objectRoot.add(mesh);
+	group.add(objectRoot);
+	return { group, mesh };
+}
+
+beforeEach(() => {
+	class FakeResizeObserver {
+		constructor(private readonly callback: ResizeObserverCallback) {}
+		observe() {
+			this.callback([], this as unknown as ResizeObserver);
+		}
+		disconnect() {}
+		unobserve() {}
+	}
+	vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+	vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+		cb(0);
+		return 1;
+	});
+	vi.stubGlobal("cancelAnimationFrame", vi.fn());
+});
+
+afterEach(async () => {
+	await cleanup();
+	vi.restoreAllMocks();
+	mocks.buildSceneGraph.mockReset();
+	mocks.buildSkyboxTexture.mockReset();
+	mocks.revokeBlobUrls.mockReset();
+});
+
+describe("Viewport", () => {
+	it("disposes replaced scene graphs and revokes stale blob URLs on rebuild", async () => {
+		const first = makeBuiltGroup();
+		const second = makeBuiltGroup();
+		const firstSkybox = { dispose: vi.fn() } as unknown as THREE.CubeTexture;
+		const secondSkybox = { dispose: vi.fn() } as unknown as THREE.CubeTexture;
+
+		const firstGeometryDispose = vi.spyOn(first.mesh.geometry, "dispose");
+		const firstMaterialDispose = vi.spyOn(first.mesh.material, "dispose");
+
+		mocks.buildSceneGraph
+			.mockResolvedValueOnce({
+				group: first.group,
+				blobUrls: ["blob:first"],
+				skyboxTexture: firstSkybox,
+			})
+			.mockResolvedValueOnce({
+				group: second.group,
+				blobUrls: ["blob:second"],
+				skyboxTexture: secondSkybox,
+			});
+
+		const ref = createRef<ViewportHandle>();
+		const dirHandle = asDirectoryHandle(MemoryDirectoryHandle.fromFiles({}));
+		const scene = makeScene();
+		const screen = await render(
+			<Viewport
+				ref={ref}
+				scene={scene}
+				dirHandle={dirHandle}
+				sceneVersion={1}
+				selectedObjectKey={null}
+				onSelectObject={vi.fn()}
+			/>,
+		);
+
+		await vi.waitFor(() => {
+			expect(mocks.buildSceneGraph).toHaveBeenCalledTimes(1);
+		});
+
+		await screen.rerender(
+			<Viewport
+				ref={ref}
+				scene={scene}
+				dirHandle={dirHandle}
+				sceneVersion={2}
+				selectedObjectKey={null}
+				onSelectObject={vi.fn()}
+			/>,
+		);
+
+		await vi.waitFor(() => {
+			expect(mocks.buildSceneGraph).toHaveBeenCalledTimes(2);
+		});
+
+		expect(mocks.revokeBlobUrls).toHaveBeenCalledWith(["blob:first"]);
+		expect(firstSkybox.dispose).toHaveBeenCalledOnce();
+		expect(firstGeometryDispose).toHaveBeenCalled();
+		expect(firstMaterialDispose).toHaveBeenCalled();
+		expect(secondSkybox.dispose).not.toHaveBeenCalled();
+	});
+});

--- a/apps/scene-previewer/test/services/jobs-store.test.ts
+++ b/apps/scene-previewer/test/services/jobs-store.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloudJob } from "../../src/services/cloud-job-types";
+
+interface FakeTx {
+	oncomplete: (() => void) | null;
+	onerror: (() => void) | null;
+	onabort: (() => void) | null;
+	error: Error | null;
+	objectStore: (name: string) => {
+		getAll: () => {
+			result?: unknown[];
+			error?: Error;
+			onsuccess: (() => void) | null;
+			onerror: (() => void) | null;
+		};
+		clear: () => void;
+		put: (value: unknown) => void;
+	};
+}
+
+function makeJob(id: string, overrides: Partial<CloudJob> = {}): CloudJob {
+	return {
+		id,
+		createdAt: Number(id.replace(/\D/g, "")) || Date.now(),
+		sceneName: `scene-${id}`,
+		status: "running",
+		...overrides,
+	};
+}
+
+function makeDb(initialRows: unknown[] = []) {
+	let rows = [...initialRows];
+	const writes: unknown[][] = [];
+
+	return {
+		get rows() {
+			return rows;
+		},
+		get writes() {
+			return writes;
+		},
+		openPreviewerDB: vi.fn(async () => ({
+			transaction: (_storeName: string, mode: "readonly" | "readwrite") => {
+				const staged: unknown[] = [];
+				const tx: FakeTx = {
+					oncomplete: null,
+					onerror: null,
+					onabort: null,
+					error: null,
+					objectStore: () => ({
+						getAll: () => {
+							const req = {
+								result: rows,
+								error: undefined,
+								onsuccess: null,
+								onerror: null,
+							};
+							queueMicrotask(() => req.onsuccess?.());
+							return req;
+						},
+						clear: () => {
+							staged.length = 0;
+						},
+						put: (value: unknown) => {
+							staged.push(structuredClone(value));
+						},
+					}),
+				};
+
+				if (mode === "readwrite") {
+					queueMicrotask(() => {
+						rows = [...staged];
+						writes.push(structuredClone(staged));
+						tx.oncomplete?.();
+					});
+				}
+
+				return tx;
+			},
+		})),
+	};
+}
+
+function installLocalStorage() {
+	const storage = new Map<string, string>();
+	vi.stubGlobal("localStorage", {
+		getItem: vi.fn((key: string) => storage.get(key) ?? null),
+		setItem: vi.fn((key: string, value: string) => {
+			storage.set(key, value);
+		}),
+		removeItem: vi.fn((key: string) => {
+			storage.delete(key);
+		}),
+		clear: vi.fn(() => {
+			storage.clear();
+		}),
+	});
+}
+
+async function loadStore({
+	persisted = [],
+	legacy = [],
+}: {
+	persisted?: unknown[];
+	legacy?: unknown[];
+} = {}) {
+	vi.resetModules();
+	installLocalStorage();
+	localStorage.clear();
+	if (legacy.length > 0) {
+		localStorage.setItem("skewer.jobs.v1", JSON.stringify(legacy));
+	}
+
+	const db = makeDb(persisted);
+	vi.doMock("../../src/services/previewer-db", () => ({
+		CLOUD_JOBS_STORE: "cloud-jobs",
+		openPreviewerDB: db.openPreviewerDB,
+	}));
+
+	const store = await import("../../src/services/jobs-store");
+	await store.whenHydrated();
+	return { store, db };
+}
+
+describe("jobs-store", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		installLocalStorage();
+		localStorage.clear();
+	});
+
+	it("hydrates from IndexedDB and legacy storage and normalizes missing previews", async () => {
+		const persisted = [
+			makeJob("persisted-1", {
+				status: "succeeded",
+				renderConfig: {
+					width: 1,
+					height: 1,
+					maxSamples: 2,
+					maxDepth: 3,
+					integrator: "path_trace",
+					startTime: 0,
+					endTime: 0,
+					fps: 24,
+					startFrame: 0,
+					endFrame: 0,
+					isAnimation: false,
+				},
+			}),
+		];
+		const legacy = [
+			makeJob("legacy-1", {
+				status: "failed",
+				compositeObjectURL: "blob:legacy-preview",
+				stitchVideoURL: "https://example/video.mp4",
+				previewLoading: false,
+				abort: new AbortController(),
+			}),
+		];
+
+		const { store, db } = await loadStore({ persisted, legacy });
+
+		expect(store.getSnapshot()).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "persisted-1",
+					status: "succeeded",
+					previewLoading: true,
+				}),
+				expect.objectContaining({
+					id: "legacy-1",
+					status: "failed",
+				}),
+			]),
+		);
+		const legacyJob = store.getSnapshot().find((job) => job.id === "legacy-1");
+		expect(legacyJob).not.toHaveProperty("abort");
+		expect(legacyJob).not.toHaveProperty("compositeObjectURL");
+		expect(legacyJob).not.toHaveProperty("stitchVideoURL");
+		expect(localStorage.getItem("skewer.jobs.v1")).toBeNull();
+		expect(db.writes.at(-1)).toEqual([
+			expect.not.objectContaining({
+				abort: expect.anything(),
+				compositeObjectURL: expect.anything(),
+				stitchVideoURL: expect.anything(),
+				previewLoading: expect.anything(),
+			}),
+			expect.not.objectContaining({
+				abort: expect.anything(),
+				compositeObjectURL: expect.anything(),
+				stitchVideoURL: expect.anything(),
+				previewLoading: expect.anything(),
+			}),
+		]);
+	});
+
+	it("prunes the oldest terminal jobs when the list exceeds capacity", async () => {
+		const revoked: string[] = [];
+		vi.spyOn(URL, "revokeObjectURL").mockImplementation((url: string) => {
+			revoked.push(url);
+		});
+
+		const { store } = await loadStore();
+		for (let i = 0; i < 20; i++) {
+			store.upsertJob(
+				makeJob(`terminal-${i}`, {
+					createdAt: i,
+					status: "succeeded",
+					compositeObjectURL: `blob:terminal-${i}`,
+				}),
+			);
+		}
+		store.upsertJob(
+			makeJob("active", {
+				createdAt: 100,
+				status: "running",
+				compositeObjectURL: "blob:active",
+			}),
+		);
+
+		expect(store.getSnapshot()).toHaveLength(20);
+		expect(store.getSnapshot().some((job) => job.id === "active")).toBe(true);
+		expect(store.getSnapshot().some((job) => job.id === "terminal-0")).toBe(
+			false,
+		);
+		expect(revoked).toEqual(["blob:terminal-0"]);
+	});
+
+	it("timestamps first terminal transition, merges renamed jobs, and revokes replaced preview URLs", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-28T12:00:00Z"));
+		const revokeObjectURL = vi
+			.spyOn(URL, "revokeObjectURL")
+			.mockImplementation(() => {});
+
+		const { store } = await loadStore();
+		store.upsertJob(
+			makeJob("local-1", {
+				createdAt: 1,
+				status: "running",
+				compositeObjectURL: "blob:old-preview",
+			}),
+		);
+
+		store.patchJob("local-1", {
+			id: "pipeline-1",
+			status: "succeeded",
+			compositeObjectURL: "blob:new-preview",
+		});
+		store.patchJob("pipeline-1", { status: "failed" });
+
+		expect(store.getSnapshot()).toEqual([
+			expect.objectContaining({
+				id: "pipeline-1",
+				status: "failed",
+				completedAt: Date.now(),
+				compositeObjectURL: "blob:new-preview",
+			}),
+		]);
+		expect(revokeObjectURL).toHaveBeenCalledWith("blob:old-preview");
+	});
+});

--- a/apps/scene-previewer/test/services/scene-history.test.ts
+++ b/apps/scene-previewer/test/services/scene-history.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	applyRedoEntry,
+	applyUndoEntry,
+	buildHistoryEntry,
+	canCoalesceHistoryEntries,
+	coalesceHistoryEntries,
+	serializeSceneFiles,
+} from "../../src/services/scene-history";
+import type { ResolvedScene } from "../../src/types/scene";
+
+function makeScene(): ResolvedScene {
+	return {
+		camera: {
+			look_from: [0, 1, 5],
+			look_at: [0, 0, 0],
+			vup: [0, 1, 0],
+			vfov: 45,
+			aperture_radius: 0,
+			focus_distance: 5,
+		},
+		contexts: [],
+		layers: [
+			{
+				name: "main",
+				path: "main.json",
+				data: {
+					materials: {
+						base: {
+							type: "lambertian",
+							albedo: [1, 0, 0],
+							emission: [0, 0, 0],
+							opacity: [1, 1, 1],
+							visible: true,
+						},
+					},
+					graph: [
+						{
+							kind: "group",
+							name: "root",
+							children: [
+								{
+									kind: "sphere",
+									name: "left",
+									material: "base",
+									center: [0, 0, 0],
+									radius: 1,
+								},
+								{
+									kind: "sphere",
+									name: "right",
+									material: "base",
+									center: [2, 0, 0],
+									radius: 2,
+								},
+							],
+						},
+					],
+				},
+			},
+		],
+		output_dir: "renders",
+		animation: { start: 0, end: 0, fps: 24, shutter_angle: 180 },
+		settings: {
+			integrator: "path_trace",
+			max_samples: 64,
+			min_samples: 4,
+			max_depth: 6,
+			threads: 0,
+			image: { width: 640, height: 360 },
+		},
+	};
+}
+
+describe("scene-history", () => {
+	it("diffs array insertion as a single add and can undo/redo it cleanly", () => {
+		const before = makeScene();
+		const inserted = structuredClone(before);
+		inserted.layers[0].data.graph[0].children.splice(1, 0, {
+			kind: "sphere",
+			name: "middle",
+			material: "base",
+			center: [1, 0, 0],
+			radius: 0.5,
+		});
+
+		const entry = buildHistoryEntry(before, inserted, "insert child");
+		expect(entry).not.toBeNull();
+		if (!entry) {
+			throw new Error("expected history entry");
+		}
+		expect(entry.deltas).toEqual([
+			expect.objectContaining({
+				operation: "add",
+				filePath: "main.json",
+				jsonPath: "/graph/0/children/1",
+				newValue: expect.objectContaining({ name: "middle" }),
+			}),
+		]);
+
+		expect(serializeSceneFiles(applyUndoEntry(inserted, entry))).toEqual(
+			serializeSceneFiles(before),
+		);
+		expect(serializeSceneFiles(applyRedoEntry(before, entry))).toEqual(
+			serializeSceneFiles(inserted),
+		);
+	});
+
+	it("treats vec3 edits atomically and preserves old values across coalesced drags", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-28T12:00:00Z"));
+
+		const start = makeScene();
+		const mid = structuredClone(start);
+		const midLeft = mid.layers[0].data.graph[0].children[0];
+		if (midLeft?.kind !== "sphere") {
+			throw new Error("expected left sphere");
+		}
+		midLeft.center = [1, 2, 3];
+		const end = structuredClone(mid);
+		const endLeft = end.layers[0].data.graph[0].children[0];
+		if (endLeft?.kind !== "sphere") {
+			throw new Error("expected left sphere");
+		}
+		endLeft.center = [4, 5, 6];
+
+		const first = buildHistoryEntry(start, mid, "drag");
+		vi.advanceTimersByTime(200);
+		const second = buildHistoryEntry(mid, end, "drag");
+		if (!first || !second) {
+			throw new Error("expected drag history entries");
+		}
+
+		expect(first.deltas).toEqual([
+			expect.objectContaining({
+				operation: "update",
+				jsonPath: "/graph/0/children/0/center",
+				oldValue: [0, 0, 0],
+				newValue: [1, 2, 3],
+			}),
+		]);
+		expect(canCoalesceHistoryEntries(first, second)).toBe(true);
+
+		const merged = coalesceHistoryEntries(first, second);
+		expect(merged.deltas).toEqual([
+			expect.objectContaining({
+				jsonPath: "/graph/0/children/0/center",
+				oldValue: [0, 0, 0],
+				newValue: [4, 5, 6],
+			}),
+		]);
+		expect(serializeSceneFiles(applyUndoEntry(end, merged))).toEqual(
+			serializeSceneFiles(start),
+		);
+		expect(serializeSceneFiles(applyRedoEntry(start, merged))).toEqual(
+			serializeSceneFiles(end),
+		);
+	});
+});

--- a/apps/scene-previewer/test/services/scene-to-three.test.ts
+++ b/apps/scene-previewer/test/services/scene-to-three.test.ts
@@ -1,0 +1,247 @@
+import * as THREE from "three";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedScene } from "../../src/types/scene";
+import { asDirectoryHandle, MemoryDirectoryHandle } from "./test-utils";
+
+function makeScene(): ResolvedScene {
+	return {
+		camera: {
+			look_from: [0, 0, 5],
+			look_at: [0, 0, 0],
+			vup: [0, 1, 0],
+			vfov: 45,
+			aperture_radius: 0,
+			focus_distance: 5,
+		},
+		contexts: [],
+		layers: [
+			{
+				name: "main",
+				path: "main.json",
+				data: {
+					materials: {
+						base: {
+							type: "lambertian",
+							albedo: [0.8, 0.8, 0.8],
+							emission: [0, 0, 0],
+							opacity: [1, 1, 1],
+							visible: true,
+						},
+					},
+					graph: [],
+				},
+			},
+		],
+		output_dir: "renders",
+		animation: { start: 0, end: 0, fps: 24, shutter_angle: 180 },
+		settings: {
+			integrator: "path_trace",
+			max_samples: 64,
+			min_samples: 4,
+			max_depth: 6,
+			threads: 0,
+			image: { width: 640, height: 360 },
+		},
+	};
+}
+
+function expectObjectAt(
+	list: THREE.Object3D[],
+	index: number,
+	label: string,
+): THREE.Object3D {
+	const value = list[index];
+	if (!value) throw new Error(`expected ${label} at index ${index}`);
+	return value;
+}
+
+describe("scene-to-three", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("assigns stable object keys through group and mesh subtrees", async () => {
+		const { buildSceneGraph } = await import(
+			"../../src/services/scene-to-three"
+		);
+		const scene = makeScene();
+		const layer = scene.layers[0];
+		if (!layer) throw new Error("expected layer");
+		layer.data.graph = [
+			{
+				kind: "group",
+				name: "root",
+				children: [
+					{
+						kind: "sphere",
+						name: "sphere",
+						material: "base",
+						center: [1, 2, 3],
+						radius: 1,
+					},
+					{
+						kind: "obj",
+						name: "missing-obj",
+						file: "missing.obj",
+					},
+				],
+			},
+		];
+
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const result = await buildSceneGraph(
+			scene,
+			asDirectoryHandle(MemoryDirectoryHandle.fromFiles({})),
+			new AbortController().signal,
+		);
+
+		const layerGroup = expectObjectAt(result.group.children, 0, "layer group");
+		const rootGroup = expectObjectAt(layerGroup.children, 0, "root group");
+		const sphereGroup = expectObjectAt(rootGroup.children, 0, "sphere group");
+		const sphereMesh = expectObjectAt(sphereGroup.children, 0, "sphere mesh");
+		const missingObjGroup = expectObjectAt(
+			rootGroup.children,
+			1,
+			"missing obj group",
+		);
+
+		expect(rootGroup.userData.objectKey).toBe("lyr:0:0");
+		expect(sphereGroup.userData.objectKey).toBe("lyr:0:0/0");
+		expect(sphereMesh.userData.objectKey).toBe("lyr:0:0/0");
+		expect(missingObjGroup.userData.objectKey).toBe("lyr:0:0/1");
+		expect(missingObjGroup.children).toHaveLength(0);
+		expect(warn).toHaveBeenCalledWith(
+			"[scene-to-three] OBJ load failed: missing.obj",
+		);
+	});
+
+	it("cleans up blob URLs and disposes built resources when construction is aborted", async () => {
+		vi.resetModules();
+		const controller = new AbortController();
+		const createObjectURL = vi
+			.spyOn(URL, "createObjectURL")
+			.mockImplementation(() => "blob:texture-1");
+		const revokeObjectURL = vi
+			.spyOn(URL, "revokeObjectURL")
+			.mockImplementation(() => {});
+		const geometryDispose = vi.spyOn(THREE.BufferGeometry.prototype, "dispose");
+		const materialDispose = vi.spyOn(THREE.Material.prototype, "dispose");
+
+		vi.doMock("three/examples/jsm/loaders/MTLLoader.js", () => ({
+			MTLLoader: class {
+				parse() {
+					return { preload() {} };
+				}
+			},
+		}));
+		vi.doMock("three/examples/jsm/loaders/OBJLoader.js", () => ({
+			OBJLoader: class {
+				setMaterials() {}
+				parse() {
+					const group = new THREE.Group();
+					group.add(
+						new THREE.Mesh(
+							new THREE.BoxGeometry(1, 1, 1),
+							new THREE.MeshBasicMaterial(),
+						),
+					);
+					return group;
+				}
+			},
+		}));
+		vi.doMock("../../src/services/fs", () => ({
+			readTextFile: vi.fn(
+				async (_dir: FileSystemDirectoryHandle, path: string) => {
+					if (path.endsWith(".obj")) {
+						return "mtllib asset.mtl\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3";
+					}
+					return "newmtl base\nmap_Kd tex.png";
+				},
+			),
+			getFile: vi.fn(async () => {
+				controller.abort();
+				return new File(["tex"], "tex.png");
+			}),
+		}));
+
+		const { buildSceneGraph } = await import(
+			"../../src/services/scene-to-three"
+		);
+		const scene = makeScene();
+		const layer = scene.layers[0];
+		if (!layer) throw new Error("expected layer");
+		layer.data.graph = [
+			{ kind: "obj", name: "mesh", file: "asset.obj" },
+			{
+				kind: "sphere",
+				name: "after-abort",
+				material: "base",
+				center: [0, 0, 0],
+				radius: 1,
+			},
+		];
+
+		const result = await buildSceneGraph(
+			scene,
+			asDirectoryHandle(MemoryDirectoryHandle.fromFiles({})),
+			controller.signal,
+		);
+
+		expect(result.blobUrls).toEqual([]);
+		expect(revokeObjectURL).toHaveBeenCalledWith("blob:texture-1");
+		expect(createObjectURL).toHaveBeenCalled();
+		expect(geometryDispose).toHaveBeenCalled();
+		expect(materialDispose).toHaveBeenCalled();
+	});
+
+	it("returns null for incomplete skyboxes instead of leaking partial texture URLs", async () => {
+		vi.resetModules();
+		vi.doUnmock("../../src/services/fs");
+		vi.doUnmock("three/examples/jsm/loaders/MTLLoader.js");
+		vi.doUnmock("three/examples/jsm/loaders/OBJLoader.js");
+
+		const createObjectURL = vi
+			.spyOn(URL, "createObjectURL")
+			.mockImplementation((file: Blob | MediaSource) => {
+				if (file instanceof File) return `blob:${file.name}`;
+				return "blob:unknown";
+			});
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		vi.doMock("three", async (importOriginal) => {
+			const actual = await importOriginal<typeof import("three")>();
+			class CubeTextureLoader {
+				load(urls: string[]) {
+					return { urls } as unknown as THREE.CubeTexture;
+				}
+			}
+			return { ...actual, CubeTextureLoader };
+		});
+
+		const { buildSkyboxTexture } = await import(
+			"../../src/services/scene-to-three"
+		);
+		const texture = await buildSkyboxTexture(
+			{
+				min: [-1, -1, -1],
+				max: [1, 1, 1],
+				faces: {
+					"+x": "px.png",
+					"-x": "missing.png",
+				},
+			},
+			asDirectoryHandle(
+				MemoryDirectoryHandle.fromFiles({
+					"px.png": new Blob(["x"]),
+				}),
+			),
+			[],
+		);
+
+		expect(texture).toBeNull();
+		expect(createObjectURL).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalledWith(
+			"[scene-to-three] Skybox face not found: missing.png",
+		);
+	});
+});


### PR DESCRIPTION
this pr adds more unit tests to increase test coverage for the following files:

`Viewport.tsx` owns critical render invalidation and graph rebuild disposal.

`jobs-store.ts` has non-trivial pruning, migration, hydration, runtime-field stripping, object URL revocation, and terminal-status timestamping with no direct tests.

Likewise, `scene-history.ts` has undo/redo JSON pointer diffing and array insertion/deletion logic with no direct tests.

Lastly, `scene-to-three.ts` builds object keys, OBJ/MTL assets, skybox textures, abort cleanup, and disposable blob URLs.

